### PR TITLE
Retire phpunit 10, migrate test metadata to attributes, add dependabot

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+# Security updates run without this file; scheduled version updates do not.
+# Groups mirror the track-admin house style, trimmed to what these forks contain
+# (no npm, and no private registry — the sibling forks are public VCS repositories).
+# Monthly rather than weekly: these forks are not actively maintained between PHP hops.
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "11:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    groups:
+      laminas-api-tools:
+        patterns:
+          - "laminas-api-tools/*"
+      laminas:
+        patterns:
+          - "laminas/*"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+      test-tooling:
+        patterns:
+          - "phpunit/*"
+          - "sebastian/*"
+          - "phpspec/*"
+      static-analysis:
+        patterns:
+          - "vimeo/psalm"
+          - "psalm/*"
+          - "squizlabs/*"
+          - "slevomat/*"
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "11:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+/.phpunit.cache/
 /.phpunit.result.cache
 /.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         }
     },
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "bshaffer/oauth2-server-php": "^1.14.1",
         "laminas-api-tools/api-tools-oauth2": "^1.11",
         "laminas/laminas-authentication": "^2.19",
@@ -44,13 +43,14 @@
         "laminas/laminas-router": "^3.16",
         "laminas/laminas-servicemanager": "^3.24",
         "laminas/laminas-stdlib": "^3.21",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "^3",
+        "laminas/laminas-coding-standard": "^3.1",
         "laminas/laminas-session": "^2.26",
         "phpspec/prophecy-phpunit": "^2.3",
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
         "psalm/plugin-phpunit": "^0.19",
         "vimeo/psalm": "^6.14"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7467fb8c86d7b2f74b2c4caa92562761",
+    "content-hash": "34bfdaefc120c2d68dfffa4ddebce9a9",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4425,35 +4425,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -4462,7 +4462,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -4491,40 +4491,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4552,36 +4564,48 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -4589,7 +4613,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4615,7 +4639,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -4623,32 +4648,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4675,7 +4700,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -4683,32 +4708,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4734,7 +4759,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -4742,20 +4768,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.64",
+            "version": "11.5.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
-                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
                 "shasum": ""
             },
             "require": {
@@ -4768,23 +4794,24 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.5",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.4",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.1",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -4795,7 +4822,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -4827,7 +4854,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
             },
             "funding": [
                 {
@@ -4835,7 +4862,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-06T14:50:35+00:00"
+            "time": "2026-07-06T14:52:39+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -5074,28 +5101,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5119,7 +5146,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -5127,32 +5154,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:12:49+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5175,7 +5202,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -5183,32 +5211,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5230,7 +5258,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -5238,36 +5267,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.5",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -5307,7 +5339,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -5327,33 +5359,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:25:16+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5377,7 +5409,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -5385,33 +5417,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5444,7 +5476,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -5452,27 +5484,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -5480,7 +5512,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -5508,42 +5540,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.4",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -5586,7 +5630,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
@@ -5606,35 +5650,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:09:11+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -5660,7 +5704,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
@@ -5668,33 +5712,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5718,7 +5762,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -5726,34 +5770,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5775,7 +5819,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -5783,32 +5828,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5830,7 +5875,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -5838,32 +5884,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5894,7 +5940,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
             },
             "funding": [
                 {
@@ -5914,32 +5960,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:50:56+00:00"
+            "time": "2025-08-13T04:42:22+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -5962,37 +6008,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2025-08-09T06:55:48+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -6015,7 +6074,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -6023,7 +6083,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -6160,16 +6220,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -6235,20 +6295,72 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.15",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
@@ -6313,7 +6425,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6333,7 +6445,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:51:00+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,9 +7,6 @@
     </UndefinedClass>
   </file>
   <file src="src/Authentication/AbstractAdapter.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getTypeFromRequest(Request $request)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$authorization->getFieldValue()]]></code>
     </MixedArgument>
@@ -81,12 +78,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[HttpAdapter]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)]]></code>
-      <code><![CDATA[public function matches($type)]]></code>
-      <code><![CDATA[public function preAuth(Request $request, Response $response)]]></code>
-      <code><![CDATA[public function provides()]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$name]]></code>
     </MixedArgument>
@@ -109,13 +100,6 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[Identity\AuthenticatedIdentity|Identity\GuestIdentity|Response]]></code>
     </ImplementedReturnTypeMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)]]></code>
-      <code><![CDATA[public function getTypeFromRequest(Request $request)]]></code>
-      <code><![CDATA[public function matches($type)]]></code>
-      <code><![CDATA[public function preAuth(Request $request, Response $response)]]></code>
-      <code><![CDATA[public function provides()]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$oauth2Response]]></code>
       <code><![CDATA[$oauth2Response->getHttpHeaders()]]></code>
@@ -170,9 +154,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AclAuthorization]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function isAuthorized(IdentityInterface $identity, $resource, $privilege)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$privilege]]></code>
       <code><![CDATA[$resource]]></code>
@@ -251,10 +232,6 @@
     <DeprecatedInterface>
       <code><![CDATA[AclAuthorizationFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$action]]></code>
       <code><![CDATA[$methods]]></code>
@@ -293,10 +270,6 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[false|ApacheResolver]]></code>
     </ImplementedReturnTypeMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[ApacheResolver::class]]></code>
     </MixedArgument>
@@ -332,10 +305,6 @@
     <DeprecatedInterface>
       <code><![CDATA[AuthenticationAdapterDelegatorFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $name, callable $callback, ?array $options = null)]]></code>
-      <code><![CDATA[public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$data]]></code>
       <code><![CDATA[$listener]]></code>
@@ -387,10 +356,6 @@
     <DeprecatedInterface>
       <code><![CDATA[AuthenticationServiceFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$container->get(NonPersistent::class)]]></code>
     </MixedArgument>
@@ -408,10 +373,6 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[HttpAuth|false]]></code>
     </ImplementedReturnTypeMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$config['api-tools-mvc-auth']['authentication']['http']]]></code>
     </MixedArgument>
@@ -434,10 +395,6 @@
     <DeprecatedInterface>
       <code><![CDATA[DefaultAuthenticationListenerFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$authService]]></code>
       <code><![CDATA[$config['api-tools-oauth2']['storage']]]></code>
@@ -492,10 +449,6 @@
     <DeprecatedInterface>
       <code><![CDATA[DefaultAuthorizationListenerFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$authorization]]></code>
       <code><![CDATA[\ZF\MvcAuth\Authorization\AuthorizationInterface::class]]></code>
@@ -519,10 +472,6 @@
     <DeprecatedInterface>
       <code><![CDATA[DefaultResourceResolverListenerFactory]]></code>
     </DeprecatedInterface>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
     </MixedArgument>
@@ -555,10 +504,6 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[false|FileResolver]]></code>
     </ImplementedReturnTypeMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$htdigest]]></code>
     </MixedArgument>
@@ -737,10 +682,6 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[null|string]]></code>
     </ImplementedReturnTypeMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getAuthenticationIdentity()]]></code>
-      <code><![CDATA[public function getRoleId()]]></code>
-    </MissingOverrideAttribute>
     <PropertyNotSetInConstructor>
       <code><![CDATA[AuthenticatedIdentity]]></code>
     </PropertyNotSetInConstructor>
@@ -749,10 +690,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[GuestIdentity]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function getAuthenticationIdentity()]]></code>
-      <code><![CDATA[public function getRoleId()]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="src/Identity/IdentityPlugin.php">
     <ClassMustBeFinal>
@@ -827,9 +764,6 @@
       <code><![CDATA[$r]]></code>
       <code><![CDATA[$r]]></code>
     </MissingClosureParamType>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function attach(EventManagerInterface $events, $priority = 1)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$mvcAuthEvent::EVENT_AUTHENTICATION]]></code>
       <code><![CDATA[$mvcAuthEvent::EVENT_AUTHENTICATION_POST]]></code>
@@ -859,32 +793,6 @@
       <code><![CDATA[DefaultAuthenticationListenerTest]]></code>
     </ClassMustBeFinal>
     <DeprecatedMethod>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
       <code><![CDATA[setHttpAdapter]]></code>
       <code><![CDATA[setHttpAdapter]]></code>
       <code><![CDATA[setHttpAdapter]]></code>
@@ -899,9 +807,6 @@
       <code><![CDATA[setOauth2Server]]></code>
       <code><![CDATA[setOauth2Server]]></code>
     </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedMethodCall>
       <code><![CDATA[set]]></code>
       <code><![CDATA[set]]></code>
@@ -970,9 +875,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthenticationPostListenerTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getReasonPhrase]]></code>
       <code><![CDATA[getStatusCode]]></code>
@@ -982,9 +884,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[HttpAdapterTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <PossiblyInvalidMethodCall>
       <code><![CDATA[addHeaderLine]]></code>
       <code><![CDATA[addHeaderLine]]></code>
@@ -998,9 +897,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[OAuth2AdapterTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$instance]]></code>
     </MixedAssignment>
@@ -1041,9 +937,6 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[new AclAuthorization()]]></code>
     </InvalidPropertyAssignmentValue>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <PossiblyInvalidArgument>
       <code><![CDATA[$routeMatch]]></code>
     </PossiblyInvalidArgument>
@@ -1067,9 +960,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthorizationPostListenerTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getReasonPhrase]]></code>
       <code><![CDATA[getStatusCode]]></code>
@@ -1081,9 +971,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[DefaultResourceResolverListenerTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedMethodCall>
       <code><![CDATA[set]]></code>
     </MixedMethodCall>
@@ -1108,9 +995,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AclAuthorizationFactoryTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$method]]></code>
@@ -1144,28 +1028,16 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationAdapterDelegatorFactoryTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/Factory/AuthenticationHttpAdapterFactoryTest.php">
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationHttpAdapterFactoryTest]]></code>
     </ClassMustBeFinal>
-    <DeprecatedMethod>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->services]]></code>
       <code><![CDATA[$this->services]]></code>
       <code><![CDATA[$this->services]]></code>
     </InvalidArgument>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <PossiblyInvalidArgument>
       <code><![CDATA[testRaisesExceptionIfMissingConfigurationOptions]]></code>
     </PossiblyInvalidArgument>
@@ -1174,24 +1046,15 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationOAuth2AdapterFactoryTest]]></code>
     </ClassMustBeFinal>
-    <DeprecatedMethod>
-      <code><![CDATA[returnValue]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->services]]></code>
       <code><![CDATA[$this->services]]></code>
     </InvalidArgument>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/Factory/DefaultAuthenticationListenerFactoryTest.php">
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthenticationListenerFactoryTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$adapters]]></code>
       <code><![CDATA[ApacheResolver::class]]></code>
@@ -1219,24 +1082,11 @@
     <ClassMustBeFinal>
       <code><![CDATA[HttpAdapterFactoryTest]]></code>
     </ClassMustBeFinal>
-    <DeprecatedMethod>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-      <code><![CDATA[returnValue]]></code>
-    </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/Factory/NamedOAuth2ServerFactoryTest.php">
     <ClassMustBeFinal>
       <code><![CDATA[NamedOAuth2ServerFactoryTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$server]]></code>
       <code><![CDATA[$server]]></code>
@@ -1276,9 +1126,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticatedIdentityTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$this->authIdentity->name]]></code>
     </MixedArgument>
@@ -1287,20 +1134,11 @@
     <ClassMustBeFinal>
       <code><![CDATA[GuestIdentityTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/Identity/IdentityPluginTest.php">
     <ClassMustBeFinal>
       <code><![CDATA[IdentityPluginTest]]></code>
     </ClassMustBeFinal>
-    <DeprecatedMethod>
-      <code><![CDATA[returnCallback]]></code>
-    </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/ModuleTest.php">
     <ClassMustBeFinal>
@@ -1313,7 +1151,7 @@
       <code><![CDATA[[]]]></code>
     </InvalidArgument>
     <InvalidDocblock>
-      <code><![CDATA[public function expectedListeners(): array]]></code>
+      <code><![CDATA[public static function expectedListeners(): array]]></code>
     </InvalidDocblock>
     <MismatchingDocblockParamType>
       <code><![CDATA[callable(MvcEvent|MvcAuthEvent):null|Response]]></code>
@@ -1352,17 +1190,11 @@
       <code><![CDATA['success']]></code>
       <code><![CDATA['success']]></code>
     </InvalidArgument>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/MvcRouteListenerTest.php">
     <ClassMustBeFinal>
       <code><![CDATA[MvcRouteListenerTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/RouteMatchFactoryTrait.php">
     <UndefinedDocblockClass>

--- a/src/Authentication/AbstractAdapter.php
+++ b/src/Authentication/AbstractAdapter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Authentication;
 
 use Laminas\Http\Request;
+use Override;
 
 use function in_array;
 use function preg_split;
@@ -27,6 +28,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @return false|string
      */
+    #[Override]
     public function getTypeFromRequest(Request $request)
     {
         $request->getHeaders();

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -10,6 +10,7 @@ use Laminas\Authentication\Adapter\Http as HttpAuth;
 use Laminas\Authentication\AuthenticationServiceInterface;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
+use Override;
 
 use function array_shift;
 use function in_array;
@@ -64,6 +65,7 @@ class HttpAdapter extends AbstractAdapter
      *
      * @return array Array of types this adapter can handle.
      */
+    #[Override]
     public function provides()
     {
         $providesBase = $this->providesBase ? $this->providesBase . '-' : '';
@@ -86,6 +88,7 @@ class HttpAdapter extends AbstractAdapter
      * @param string $type
      * @return bool
      */
+    #[Override]
     public function matches($type)
     {
         return $this->providesBase === $type || in_array($type, $this->provides(), true);
@@ -98,6 +101,7 @@ class HttpAdapter extends AbstractAdapter
      *
      * @return void
      */
+    #[Override]
     public function preAuth(Request $request, Response $response)
     {
         $this->httpAuth->setRequest($request);
@@ -111,6 +115,7 @@ class HttpAdapter extends AbstractAdapter
      * @return false|Identity\IdentityInterface False on failure, IdentityInterface
      *     otherwise
      */
+    #[Override]
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
         if (! $request->getHeader('Authorization', false)) {

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -11,6 +11,7 @@ use Laminas\Http\Response;
 use OAuth2\Request as OAuth2Request;
 use OAuth2\Response as OAuth2Response;
 use OAuth2\Server as OAuth2Server;
+use Override;
 
 use function in_array;
 use function is_array;
@@ -64,6 +65,7 @@ class OAuth2Adapter extends AbstractAdapter
     /**
      * @return array Array of types this adapter can handle.
      */
+    #[Override]
     public function provides()
     {
         return $this->providesTypes;
@@ -76,6 +78,7 @@ class OAuth2Adapter extends AbstractAdapter
      * @param string $type
      * @return bool
      */
+    #[Override]
     public function matches($type)
     {
         return in_array($type, $this->providesTypes, true);
@@ -86,6 +89,7 @@ class OAuth2Adapter extends AbstractAdapter
      *
      * @return false|string
      */
+    #[Override]
     public function getTypeFromRequest(Request $request)
     {
         $type = parent::getTypeFromRequest($request);
@@ -117,6 +121,7 @@ class OAuth2Adapter extends AbstractAdapter
      *
      * @return void
      */
+    #[Override]
     public function preAuth(Request $request, Response $response)
     {
     }
@@ -126,6 +131,7 @@ class OAuth2Adapter extends AbstractAdapter
      *
      * @return Identity\AuthenticatedIdentity|Identity\GuestIdentity|Response
      */
+    #[Override]
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
         $oauth2request = new OAuth2Request(

--- a/src/Authorization/AclAuthorization.php
+++ b/src/Authorization/AclAuthorization.php
@@ -6,6 +6,7 @@ namespace Laminas\ApiTools\MvcAuth\Authorization;
 
 use Laminas\ApiTools\MvcAuth\Identity\IdentityInterface;
 use Laminas\Permissions\Acl\Acl;
+use Override;
 
 /**
  * Authorization implementation that uses the ACL component
@@ -21,6 +22,7 @@ class AclAuthorization extends Acl implements AuthorizationInterface
      * @param mixed $privilege
      * @return bool
      */
+    #[Override]
     public function isAuthorized(IdentityInterface $identity, $resource, $privilege)
     {
         if (null !== $resource && (! $this->hasResource($resource))) {

--- a/src/Factory/AclAuthorizationFactory.php
+++ b/src/Factory/AclAuthorizationFactory.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\MvcAuth\Authorization\AclAuthorizationFactory as AclFactory
 use Laminas\Http\Request;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 use function array_key_exists;
@@ -38,6 +39,7 @@ class AclAuthorizationFactory implements FactoryInterface
      * @param null|array $options
      * @return AclAuthorization
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $config = $this->getConfigFromContainer($container);
@@ -51,6 +53,7 @@ class AclAuthorizationFactory implements FactoryInterface
      *
      * @return AclAuthorization
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, AclAuthorization::class);

--- a/src/Factory/ApacheResolverFactory.php
+++ b/src/Factory/ApacheResolverFactory.php
@@ -6,6 +6,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 class ApacheResolverFactory implements FactoryInterface
@@ -19,6 +20,7 @@ class ApacheResolverFactory implements FactoryInterface
      * @param null|array $options
      * @return false|ApacheResolver
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         if (false === $container->has('config')) {
@@ -43,6 +45,7 @@ class ApacheResolverFactory implements FactoryInterface
      *
      * @return false|ApacheResolver
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, ApacheResolver::class);

--- a/src/Factory/AuthenticationAdapterDelegatorFactory.php
+++ b/src/Factory/AuthenticationAdapterDelegatorFactory.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\MvcAuth\Authentication\HttpAdapter;
 use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ServiceManager\DelegatorFactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 use function is_array;
@@ -25,6 +26,7 @@ class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
      * @param  null|array         $options
      * @return DefaultAuthenticationListener
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $name, callable $callback, ?array $options = null)
     {
         $listener = $callback();
@@ -54,6 +56,7 @@ class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
      * @param callable $callback
      * @return DefaultAuthenticationListener
      */
+    #[Override]
     public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)
     {
         return $this($container, $requestedName, $callback);

--- a/src/Factory/AuthenticationServiceFactory.php
+++ b/src/Factory/AuthenticationServiceFactory.php
@@ -8,6 +8,7 @@ use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\Storage\NonPersistent;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 class AuthenticationServiceFactory implements FactoryInterface
@@ -19,6 +20,7 @@ class AuthenticationServiceFactory implements FactoryInterface
      * @param null|array $options
      * @return AuthenticationService
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new AuthenticationService($container->get(NonPersistent::class));
@@ -31,6 +33,7 @@ class AuthenticationServiceFactory implements FactoryInterface
      *
      * @return AuthenticationService
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, AuthenticationService::class);

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -7,6 +7,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 use Laminas\Authentication\Adapter\Http as HttpAuth;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -21,6 +22,7 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
      * @param null|array $options
      * @return HttpAuth|false
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         // If no configuration present, nothing to create
@@ -45,6 +47,7 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
      *
      * @return HttpAuth|false
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, HttpAuth::class);

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -10,6 +10,7 @@ use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ApiTools\OAuth2\Factory\OAuth2ServerFactory as LaminasOAuth2ServerFactory;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
@@ -29,6 +30,7 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
      * @param null|array         $options
      * @return DefaultAuthenticationListener
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $listener = new DefaultAuthenticationListener();
@@ -60,6 +62,7 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
      *
      * @return DefaultAuthenticationListener
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, DefaultAuthenticationListener::class);

--- a/src/Factory/DefaultAuthorizationListenerFactory.php
+++ b/src/Factory/DefaultAuthorizationListenerFactory.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\MvcAuth\Authorization\DefaultAuthorizationListener;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 use function sprintf;
@@ -26,6 +27,7 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
      * @return DefaultAuthorizationListener
      * @throws ServiceNotCreatedException If the AuthorizationInterface service is missing.
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         if (
@@ -53,6 +55,7 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
      *
      * @return DefaultAuthorizationListener
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, DefaultAuthorizationListener::class);

--- a/src/Factory/DefaultResourceResolverListenerFactory.php
+++ b/src/Factory/DefaultResourceResolverListenerFactory.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\MvcAuth\Authorization\DefaultResourceResolverListener;
 use Laminas\Http\Request;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -31,6 +32,7 @@ class DefaultResourceResolverListenerFactory implements FactoryInterface
      * @param null|array         $options
      * @return DefaultResourceResolverListener
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $config = $container->has('config') ? $container->get('config') : [];
@@ -47,6 +49,7 @@ class DefaultResourceResolverListenerFactory implements FactoryInterface
      *
      * @return DefaultResourceResolverListener
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, DefaultResourceResolverListener::class);

--- a/src/Factory/FileResolverFactory.php
+++ b/src/Factory/FileResolverFactory.php
@@ -7,6 +7,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 use Laminas\Authentication\Adapter\Http\FileResolver;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 class FileResolverFactory implements FactoryInterface
@@ -18,6 +19,7 @@ class FileResolverFactory implements FactoryInterface
      * @param null|array         $options
      * @return false|FileResolver
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         if (! $container->has('config')) {
@@ -42,6 +44,7 @@ class FileResolverFactory implements FactoryInterface
      *
      * @return false|FileResolver
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container)
     {
         return $this($container, FileResolver::class);

--- a/src/Identity/AuthenticatedIdentity.php
+++ b/src/Identity/AuthenticatedIdentity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Identity;
 
 use Laminas\Permissions\Rbac\Role;
+use Override;
 
 class AuthenticatedIdentity extends Role implements IdentityInterface
 {
@@ -18,12 +19,14 @@ class AuthenticatedIdentity extends Role implements IdentityInterface
     }
 
     /** @return null|string */
+    #[Override]
     public function getRoleId()
     {
         return $this->name;
     }
 
     /** @return mixed */
+    #[Override]
     public function getAuthenticationIdentity()
     {
         return $this->identity;

--- a/src/Identity/GuestIdentity.php
+++ b/src/Identity/GuestIdentity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Identity;
 
 use Laminas\Permissions\Rbac\Role;
+use Override;
 
 class GuestIdentity extends Role implements IdentityInterface
 {
@@ -17,12 +18,14 @@ class GuestIdentity extends Role implements IdentityInterface
     }
 
     /** @return string */
+    #[Override]
     public function getRoleId()
     {
         return static::$identity;
     }
 
     /** @return null */
+    #[Override]
     public function getAuthenticationIdentity()
     {
         return null;

--- a/src/MvcRouteListener.php
+++ b/src/MvcRouteListener.php
@@ -11,6 +11,7 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\ResponseInterface as Response;
+use Override;
 
 use function is_bool;
 
@@ -42,6 +43,7 @@ class MvcRouteListener extends AbstractListenerAggregate
      *
      * @param int $priority
      */
+    #[Override]
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'authentication'], -50);

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -23,6 +23,10 @@ use Laminas\Stdlib\Request;
 use LaminasTest\ApiTools\MvcAuth\RouteMatchFactoryTrait;
 use OAuth2\Request as OAuth2Request;
 use OAuth2\Server as OAuth2Server;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -56,6 +60,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /** @var Config */
     protected $configuration;
 
+    #[Override]
     public function setUp(): void
     {
         // authentication service
@@ -182,9 +187,9 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @depends testInvokeForBasicAuthSetsIdentityWhenValid
      * @psalm-param array{identity: array, mvc_event: MvcEvent} $params
      */
+    #[Depends('testInvokeForBasicAuthSetsIdentityWhenValid')]
     public function testListenerInjectsDiscoveredIdentityIntoMvcEvent(array $params): void
     {
         $identity = $params['identity'];
@@ -195,9 +200,9 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @depends testInvokeForBasicAuthSetsGuestIdentityWhenValid
      * @psalm-param array{identity: array, mvc_event: MvcEvent} $params
      */
+    #[Depends('testInvokeForBasicAuthSetsGuestIdentityWhenValid')]
     public function testListenerInjectsGuestIdentityIntoMvcEvent(array $params): void
     {
         $identity = $params['identity'];
@@ -207,9 +212,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertSame($identity, $received);
     }
 
-    /**
-     * @group 23
-     */
+    #[Group('23')]
     public function testListenerPullsDigestUsernameFromAuthenticationIdentityWhenCreatingAuthenticatedIdentityInstance(): void
     {
         $httpAuth       = $this->getMockBuilder(HttpAuth::class)
@@ -221,13 +224,13 @@ class DefaultAuthenticationListenerTest extends TestCase
         ]);
         $httpAuth->expects($this->any())
             ->method('getBasicResolver')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $httpAuth->expects($this->any())
             ->method('getDigestResolver')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $httpAuth->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($resultIdentity));
+            ->willReturn($resultIdentity);
 
         $this->listener->setHttpAdapter($httpAuth);
         $this->request->getHeaders()->addHeaderLine(
@@ -286,9 +289,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider requestMethodsWithRequestBodies
-     */
+    #[DataProvider('requestMethodsWithRequestBodies')]
     public function testBodyAccessTokenProxiesOAuthServer(string $method): void
     {
         $token = [
@@ -313,7 +314,7 @@ class DefaultAuthenticationListenerTest extends TestCase
 
         $server->expects($this->atLeastOnce())
             ->method('getAccessTokenData')
-            ->will($this->returnValue($token));
+            ->willReturn($token);
 
         $this->listener->setOauth2Server($server);
     }
@@ -351,10 +352,10 @@ class DefaultAuthenticationListenerTest extends TestCase
         ]);
         $httpAuth->expects($this->any())
             ->method('getDigestResolver')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $httpAuth->expects($this->once())
             ->method('authenticate')
-            ->will($this->returnValue($resultIdentity));
+            ->willReturn($resultIdentity);
 
         $this->listener->setHttpAdapter($httpAuth);
     }
@@ -442,10 +443,10 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider mappedAuthenticationControllers
-     * @group 55
      * @psalm-param callable():HttpRequest $requestProvider
      */
+    #[DataProvider('mappedAuthenticationControllers')]
+    #[Group('55')]
     public function testAuthenticationUsesMapByToChooseAuthenticationMethod(
         string $controller,
         string $authType,
@@ -457,10 +458,10 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider mappedAuthenticationControllers
-     * @group 55
      * @psalm-param callable():HttpRequest $requestProvider
      */
+    #[DataProvider('mappedAuthenticationControllers')]
+    #[Group('55')]
     public function testGuestIdentityIsReturnedWhenNoAuthSchemesArePresent(
         string $controller,
         string $authType,
@@ -482,10 +483,10 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider mappedAuthenticationControllers
-     * @group 55
      * @psalm-param callable():HttpRequest $requestProvider
      */
+    #[DataProvider('mappedAuthenticationControllers')]
+    #[Group('55')]
     public function testUsesDefaultAuthenticationWhenNoAuthMapIsPresent(
         string $controller,
         string $authType,
@@ -515,10 +516,10 @@ class DefaultAuthenticationListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider mappedAuthenticationControllers
-     * @group 55
      * @psalm-param callable():HttpRequest $requestProvider
      */
+    #[DataProvider('mappedAuthenticationControllers')]
+    #[Group('55')]
     public function testDoesNotPerformAuthenticationWhenNoAuthMapPresentAndMultipleAuthSchemesAreDefined(
         string $controller,
         string $authType,
@@ -541,9 +542,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $identity);
     }
 
-    /**
-     * @group 55
-     */
+    #[Group('55')]
     public function testDoesNotPerformAuthenticationWhenMatchedControllerHasNoAuthMapEntryAndAuthSchemesAreDefined(): void
     {
         // Minimal HTTP adapter mock, as we are not expecting any method calls
@@ -579,9 +578,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $identity);
     }
 
-    /**
-     * @group 55
-     */
+    #[Group('55')]
     public function testDoesNotPerformAuthenticationWhenMatchedControllerHasAuthMapEntryNotInDefinedAuthSchemes(): void
     {
         // Minimal HTTP adapter mock, as we are not expecting any method calls
@@ -621,7 +618,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $this->listener->attach($adapter);
     }
 
@@ -633,7 +630,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $this->listener->attach($adapter);
         $this->assertEquals($types, $this->listener->getAuthenticationTypes());
     }
@@ -659,15 +656,15 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $adapter->expects($this->once())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $adapter->expects($this->once())
             ->method('preAuth')
             ->with($this->equalTo($request), $this->equalTo($this->response))
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->listener->attach($adapter);
 
@@ -696,22 +693,22 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $adapter->expects($this->any())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
-            ->will($this->returnValue('oauth2'));
+            ->willReturn('oauth2');
         $adapter->expects($this->any())
             ->method('matches')
             ->with($this->equalTo('oauth2'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $expected = $this->getMockBuilder(AuthenticatedIdentity::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adapter->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($request), $this->equalTo($this->response))
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
         $this->listener->attach($adapter);
 
         $identity = $this->listener->__invoke($this->mvcAuthEvent);
@@ -739,33 +736,33 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter1->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $adapter1->expects($this->any())
             ->method('matches')
             ->with($this->equalTo('oauth2'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $adapter1->expects($this->any())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
-            ->will($this->returnValue('oauth2'));
+            ->willReturn('oauth2');
         $expected = $this->getMockBuilder(AuthenticatedIdentity::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adapter1->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($request), $this->equalTo($this->response))
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $adapter2 = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adapter2->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $adapter2->expects($this->any())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
-            ->will($this->returnValue('oauth2'));
+            ->willReturn('oauth2');
 
         $this->listener->attach($adapter1);
         $this->listener->attach($adapter2);
@@ -792,7 +789,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $this->listener->attach($adapter);
 
         // Order of merge matters, unfortunately
@@ -818,9 +815,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->listener->__invoke($this->mvcAuthEvent);
     }
 
-    /**
-     * @group 83
-     */
+    #[Group('83')]
     public function testAllowsAdaptersToReturnResponsesAndReturnsThemDirectly(): void
     {
         $map = [
@@ -840,15 +835,15 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
-            ->will($this->returnValue($types));
+            ->willReturn($types);
         $adapter->expects($this->any())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
-            ->will($this->returnValue('custom'));
+            ->willReturn('custom');
         $adapter->expects($this->any())
             ->method('matches')
             ->with($this->equalTo('custom'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $response = new HttpResponse();
         $response->setStatusCode(401);
@@ -856,7 +851,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($request), $this->equalTo($this->response))
-            ->will($this->returnValue($response));
+            ->willReturn($response);
         $this->listener->attach($adapter);
 
         $result = $this->listener->__invoke($this->mvcAuthEvent);

--- a/test/Authentication/DefaultAuthenticationPostListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationPostListenerTest.php
@@ -12,6 +12,7 @@ use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\Response;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
+use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,7 @@ class DefaultAuthenticationPostListenerTest extends TestCase
     protected TestAsset\AuthenticationService $authentication;
     protected MockObject $authorization;
 
+    #[Override]
     public function setUp(): void
     {
         $response = new HttpResponse();

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -15,6 +15,7 @@ use Laminas\Authentication\Storage\NonPersistent;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class HttpAdapterTest extends TestCase
@@ -24,6 +25,7 @@ class HttpAdapterTest extends TestCase
     protected HttpResponse $response;
     protected MvcAuthEvent $event;
 
+    #[Override]
     public function setUp(): void
     {
         // authentication service

--- a/test/Authentication/OAuth2AdapterTest.php
+++ b/test/Authentication/OAuth2AdapterTest.php
@@ -13,6 +13,8 @@ use Laminas\Http\Response as HttpResponse;
 use OAuth2\Request as OAuth2Request;
 use OAuth2\Response as OAuth2Response;
 use OAuth2\Server as OAuth2Server;
+use Override;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -21,15 +23,14 @@ class OAuth2AdapterTest extends TestCase
     protected OAuth2Adapter $adapter;
     protected MockObject $oauthServer;
 
+    #[Override]
     public function setUp(): void
     {
         $this->oauthServer = $this->getMockBuilder(OAuth2Server::class)->getMock();
         $this->adapter     = new OAuth2Adapter($this->oauthServer);
     }
 
-    /**
-     * @group 83
-     */
+    #[Group('83')]
     public function testReturns401ResponseWhenErrorOccursDuringValidation(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
@@ -71,9 +72,7 @@ class OAuth2AdapterTest extends TestCase
         $this->assertEquals(401, $result->getStatusCode());
     }
 
-    /**
-     * @group 83
-     */
+    #[Group('83')]
     public function testReturns403ResponseWhenInvalidScopeDetected(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
@@ -115,9 +114,7 @@ class OAuth2AdapterTest extends TestCase
         $this->assertEquals(403, $result->getStatusCode());
     }
 
-    /**
-     * @group 83
-     */
+    #[Group('83')]
     public function testReturnsGuestIdentityIfOAuth2ResponseIsNotAnError(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
@@ -153,9 +150,7 @@ class OAuth2AdapterTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $result);
     }
 
-    /**
-     * @group 83
-     */
+    #[Group('83')]
     public function testErrorResponseIncludesOAuth2ResponseHeaders(): void
     {
         $expectedHeaders = [

--- a/test/Authorization/DefaultAuthorizationListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationListenerTest.php
@@ -19,6 +19,7 @@ use Laminas\Stdlib\Request;
 use Laminas\Stdlib\Response;
 use LaminasTest\ApiTools\MvcAuth\RouteMatchFactoryTrait;
 use LaminasTest\ApiTools\MvcAuth\TestAsset\AuthenticationService;
+use Override;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -43,6 +44,7 @@ class DefaultAuthorizationListenerTest extends TestCase
     /** @var MvcAuthEvent */
     protected $mvcAuthEvent;
 
+    #[Override]
     public function setUp(): void
     {
         // authentication service

--- a/test/Authorization/DefaultAuthorizationPostListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationPostListenerTest.php
@@ -11,6 +11,7 @@ use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\Response;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
+use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +22,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
     protected TestAsset\AuthenticationService $authentication;
     protected MockObject $authorization;
 
+    #[Override]
     public function setUp(): void
     {
         $response = new HttpResponse();

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -12,6 +12,7 @@ use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use LaminasTest\ApiTools\MvcAuth\RouteMatchFactoryTrait;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
+use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -25,6 +26,7 @@ class DefaultResourceResolverListenerTest extends TestCase
     protected TestAsset\AuthenticationService $authentication;
     protected MockObject $authorization;
 
+    #[Override]
     public function setUp(): void
     {
         $routeMatch = $this->createRouteMatch([]);

--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\ApiTools\MvcAuth\Factory;
 use Laminas\ApiTools\MvcAuth\Authorization\AclAuthorization;
 use Laminas\ApiTools\MvcAuth\Factory\AclAuthorizationFactory;
 use Laminas\ServiceManager\ServiceManager;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_key_exists;
@@ -20,6 +22,7 @@ class AclAuthorizationFactoryTest extends TestCase
     /** @var ServiceManager */
     private $services;
 
+    #[Override]
     public function setUp(): void
     {
         $this->services = new ServiceManager();
@@ -72,9 +75,7 @@ class AclAuthorizationFactoryTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider whitelistAclProvider
-     */
+    #[DataProvider('whitelistAclProvider')]
     public function testCanCreateWhitelistAcl(array $config): void
     {
         $this->services->setService('config', $config);

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -11,6 +11,7 @@ use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ApiTools\MvcAuth\Factory\AuthenticationAdapterDelegatorFactory;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\ServiceManager\ServiceManager;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class AuthenticationAdapterDelegatorFactoryTest extends TestCase
@@ -20,6 +21,7 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
     protected DefaultAuthenticationListener $listener;
     protected Closure $callback;
 
+    #[Override]
     public function setUp(): void
     {
         // Actual service manager instance, as multiple services may be

--- a/test/Factory/AuthenticationHttpAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationHttpAdapterFactoryTest.php
@@ -9,6 +9,8 @@ use Laminas\ApiTools\MvcAuth\Factory\AuthenticationHttpAdapterFactory;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -16,6 +18,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
 {
     protected MockObject $services;
 
+    #[Override]
     public function setUp(): void
     {
         $this->services = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
@@ -26,7 +29,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
         $this->services->expects($this->atLeastOnce())
             ->method('has')
             ->with($this->equalTo('authentication'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('missing AuthenticationService');
@@ -48,15 +51,15 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidConfiguration
      * @psalm-param array<string, mixed> $config
      */
+    #[DataProvider('invalidConfiguration')]
     public function testRaisesExceptionIfMissingConfigurationOptions(array $config): void
     {
         $this->services->expects($this->atLeastOnce())
             ->method('has')
             ->with($this->equalTo('authentication'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('missing options');
@@ -102,21 +105,21 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider validConfiguration
      * @psalm-param array<string, mixed> $options
      * @psalm-param string[] $provides
      */
+    #[DataProvider('validConfiguration')]
     public function testCreatesHttpAdapterWhenConfigurationIsValid(array $options, array $provides): void
     {
         $authService = $this->getMockBuilder(AuthenticationService::class)->getMock();
         $this->services->expects($this->atLeastOnce())
             ->method('has')
             ->with($this->equalTo('authentication'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->services->expects($this->atLeastOnce())
             ->method('get')
             ->with($this->equalTo('authentication'))
-            ->will($this->returnValue($authService));
+            ->willReturn($authService);
 
         $adapter = AuthenticationHttpAdapterFactory::factory('foo', ['options' => $options], $this->services);
         $this->assertInstanceOf(HttpAdapter::class, $adapter);

--- a/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
+++ b/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
@@ -8,6 +8,8 @@ use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ApiTools\MvcAuth\Factory\AuthenticationOAuth2AdapterFactory;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -15,6 +17,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
 {
     protected MockObject $services;
 
+    #[Override]
     public function setUp(): void
     {
         $this->services = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
@@ -35,9 +38,9 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidConfiguration
      * @psalm-param array<array-key, mixed> $config
      */
+    #[DataProvider('invalidConfiguration')]
     public function testRaisesExceptionForMissingOrInvalidStorage(array $config): void
     {
         $this->expectException(ServiceNotCreatedException::class);
@@ -58,7 +61,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
         $this->services->expects($this->any())
             ->method('get')
             ->with($this->stringContains('Config'))
-            ->will($this->returnValue([
+            ->willReturn([
                 'api-tools-oauth2' => [
                     'grant_types'                => [
                         'client_credentials' => true,
@@ -69,7 +72,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
                     ],
                     'api_problem_error_response' => true,
                 ],
-            ]));
+            ]);
 
         $adapter = AuthenticationOAuth2AdapterFactory::factory('foo', $config, $this->services);
         $this->assertInstanceOf(OAuth2Adapter::class, $adapter);

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -16,6 +16,7 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
 use OAuth2\Server as OAuth2Server;
 use OAuth2\Storage\Pdo as PdoStorage;
+use Override;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use ReflectionProperty;
@@ -30,6 +31,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
     /** @var ServiceManager */
     private $services;
 
+    #[Override]
     public function setUp(): void
     {
         $this->services = new ServiceManager();

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -11,6 +11,8 @@ use Laminas\Authentication\Adapter\Http\FileResolver;
 use Laminas\Authentication\Adapter\Http\ResolverInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class HttpAdapterFactoryTest extends TestCase
@@ -21,6 +23,7 @@ class HttpAdapterFactoryTest extends TestCase
     /** @var string */
     private $htdigest;
 
+    #[Override]
     public function setUp(): void
     {
         $this->htpasswd = __DIR__ . '/../TestAsset/htpasswd';
@@ -51,9 +54,9 @@ class HttpAdapterFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidAcceptSchemes
      * @param mixed $acceptSchemes
      */
+    #[DataProvider('invalidAcceptSchemes')]
     public function testFactoryRaisesExceptionWhenAcceptSchemesIsNotAnArray($acceptSchemes): void
     {
         $this->expectException(ServiceNotCreatedException::class);
@@ -122,9 +125,9 @@ class HttpAdapterFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider validConfigWithoutResolvers
      * @psalm-param array<string, mixed> $config
      */
+    #[DataProvider('validConfigWithoutResolvers')]
     public function testCanReturnAdapterWithNoResolvers(array $config): void
     {
         $adapter = HttpAdapterFactory::factory($config);
@@ -186,14 +189,14 @@ class HttpAdapterFactoryTest extends TestCase
             ->expects($this->once())
             ->method('has')
             ->with($keyForServiceManager)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = $this->getMockBuilder(ResolverInterface::class)->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('get')
             ->with($keyForServiceManager)
-            ->will($this->returnValue($resolver));
+            ->willReturn($resolver);
 
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes'         => ['basic', 'digest'],
@@ -218,14 +221,14 @@ class HttpAdapterFactoryTest extends TestCase
             ->expects($this->once())
             ->method('has')
             ->with($keyForServiceManager)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resolver = $this->getMockBuilder(ResolverInterface::class)->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('get')
             ->with($keyForServiceManager)
-            ->will($this->returnValue($resolver));
+            ->willReturn($resolver);
 
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes'          => ['basic', 'digest'],
@@ -285,7 +288,7 @@ class HttpAdapterFactoryTest extends TestCase
             ->expects($this->any())
             ->method('has')
             ->with($missingKeyForServiceManager)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceManager
             ->expects($this->never())
             ->method('get');

--- a/test/Factory/NamedOAuth2ServerFactoryTest.php
+++ b/test/Factory/NamedOAuth2ServerFactoryTest.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ApiTools\MvcAuth\Factory\NamedOAuth2ServerFactory;
 use Laminas\ServiceManager\ServiceManager;
 use OAuth2\Storage\Memory as MemoryStorage;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class NamedOAuth2ServerFactoryTest extends TestCase
@@ -15,6 +16,7 @@ class NamedOAuth2ServerFactoryTest extends TestCase
     protected ServiceManager $services;
     protected NamedOAuth2ServerFactory $factory;
 
+    #[Override]
     public function setUp(): void
     {
         $this->services = $this->setUpConfig(new ServiceManager());

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -11,6 +11,8 @@ use MongoDB;
 use OAuth2\GrantType;
 use OAuth2\OpenID\GrantType\AuthorizationCode as OpenIDAuthorizationCodeGrantType;
 use OAuth2\Server as OAuth2Server;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -146,10 +148,8 @@ class OAuth2ServerFactoryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider disableGrantType
-     * @group 77
-     */
+    #[DataProvider('disableGrantType')]
+    #[Group('77')]
     public function testServerCreatedHasDefaultGrantTypesAsDefinedByOAuth2Module(string $disable): void
     {
         $options                                              = $this->getOAuth2Options();

--- a/test/Identity/AuthenticatedIdentityTest.php
+++ b/test/Identity/AuthenticatedIdentityTest.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\MvcAuth\Identity\AuthenticatedIdentity;
 use Laminas\ApiTools\MvcAuth\Identity\IdentityInterface;
 use Laminas\Permissions\Acl\Role\RoleInterface as AclRoleInterface;
 use Laminas\Permissions\Rbac\RoleInterface as RbacRoleInterface;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class AuthenticatedIdentityTest extends TestCase
@@ -15,6 +16,7 @@ class AuthenticatedIdentityTest extends TestCase
     protected object $authIdentity;
     protected AuthenticatedIdentity $identity;
 
+    #[Override]
     public function setUp(): void
     {
         $this->authIdentity = (object) [

--- a/test/Identity/GuestIdentityTest.php
+++ b/test/Identity/GuestIdentityTest.php
@@ -8,12 +8,14 @@ use Laminas\ApiTools\MvcAuth\Identity\GuestIdentity;
 use Laminas\ApiTools\MvcAuth\Identity\IdentityInterface;
 use Laminas\Permissions\Acl\Role\RoleInterface as AclRoleInterface;
 use Laminas\Permissions\Rbac\RoleInterface as RbacRoleInterface;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class GuestIdentityTest extends TestCase
 {
     protected GuestIdentity $identity;
 
+    #[Override]
     public function setUp(): void
     {
         $this->identity = new GuestIdentity();

--- a/test/Identity/IdentityPluginTest.php
+++ b/test/Identity/IdentityPluginTest.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\MvcAuth\Identity\GuestIdentity;
 use Laminas\ApiTools\MvcAuth\Identity\IdentityPlugin;
 use Laminas\Mvc\Controller\AbstractController;
 use Laminas\Mvc\MvcEvent;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class IdentityPluginTest extends TestCase
@@ -16,6 +17,7 @@ class IdentityPluginTest extends TestCase
     protected IdentityPlugin $plugin;
     protected MvcEvent $event;
 
+    #[Override]
     public function setUp(): void
     {
         $this->event = $event = new MvcEvent();
@@ -23,9 +25,9 @@ class IdentityPluginTest extends TestCase
         $controller = $this->getMockBuilder(AbstractController::class)->getMock();
         $controller->expects($this->any())
             ->method('getEvent')
-            ->will($this->returnCallback(function () use ($event) {
+            ->willReturnCallback(function () use ($event) {
                 return $event;
-            }));
+            });
 
         $this->plugin = new IdentityPlugin();
         $this->plugin->setController($controller);

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -21,6 +21,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\RequestInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionMethod;
@@ -32,7 +33,7 @@ class ModuleTest extends TestCase
     use EventListenerIntrospectionTrait;
     use ProphecyTrait;
 
-    protected function createApplication(ServiceManager $services, EventManagerInterface $events): Application
+    protected static function createApplication(ServiceManager $services, EventManagerInterface $events): Application
     {
         $r = new ReflectionMethod(Application::class, '__construct');
         if ($r->getNumberOfRequiredParameters() === 2) {
@@ -45,7 +46,7 @@ class ModuleTest extends TestCase
     }
 
     /** @psalm-param array<string, mixed> $config */
-    protected function createServiceManager(array $config): ServiceManager
+    protected static function createServiceManager(array $config): ServiceManager
     {
         if (method_exists(ServiceManager::class, 'configure')) { // v3
             // laminas-servicemanager v3
@@ -77,21 +78,21 @@ class ModuleTest extends TestCase
      *     3: EventManager
      * }>
      */
-    public function expectedListeners(): array
+    public static function expectedListeners(): array
     {
         $module   = new Module();
         $config   = $module->getConfig();
-        $request  = $this->prophesize(Request::class)->reveal();
-        $response = $this->prophesize(Response::class)->reveal();
+        $request  = new Request();
+        $response = new Response();
 
-        $services = $this->createServiceManager($config);
+        $services = self::createServiceManager($config);
         $services->setService('Request', $request);
         $services->setService('Response', $response);
         $services->setService('config', $config);
 
         $events = new EventManager();
 
-        $application = $this->createApplication($services, $events);
+        $application = self::createApplication($services, $events);
 
         $mvcEvent = new MvcEvent(MvcEvent::EVENT_BOOTSTRAP);
         $mvcEvent->setApplication($application);
@@ -117,10 +118,10 @@ class ModuleTest extends TestCase
     }
 
     /**
-     * @dataProvider expectedListeners
      * @psalm-param callable(MvcEvent|MvcAuthEvent):null|Response $listener
      * @psalm-param MvcEvent::EVENT_*|MvcAuthEvent::EVENT_* $event
      */
+    #[DataProvider('expectedListeners')]
     public function testOnBootstrapAttachesListeners(
         callable $listener,
         int $priority,

--- a/test/MvcAuthEventTest.php
+++ b/test/MvcAuthEventTest.php
@@ -10,6 +10,8 @@ use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\Result;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Permissions\Acl\Acl;
+use Override;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 class MvcAuthEventTest extends TestCase
@@ -17,6 +19,7 @@ class MvcAuthEventTest extends TestCase
     /** @var MvcAuthEvent */
     protected $mvcAuthEvent;
 
+    #[Override]
     public function setUp(): void
     {
         $mvcEvent           = new MvcEvent();
@@ -75,9 +78,7 @@ class MvcAuthEventTest extends TestCase
         $this->assertNull($this->mvcAuthEvent->getResource());
     }
 
-    /**
-     * @depends testResourceStringIsNullByDefault
-     */
+    #[Depends('testResourceStringIsNullByDefault')]
     public function testResourceStringIsMutable(): void
     {
         $this->mvcAuthEvent->setResource('foo');
@@ -89,9 +90,7 @@ class MvcAuthEventTest extends TestCase
         $this->assertFalse($this->mvcAuthEvent->isAuthorized());
     }
 
-    /**
-     * @depends testAuthorizedFlagIsFalseByDefault
-     */
+    #[Depends('testAuthorizedFlagIsFalseByDefault')]
     public function testAuthorizedFlagIsMutable(): void
     {
         $this->mvcAuthEvent->setIsAuthorized(true);

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -10,6 +10,7 @@ use Laminas\Authentication\AuthenticationService;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
 use Laminas\Mvc\MvcEvent;
+use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -29,6 +30,7 @@ class MvcRouteListenerTest extends TestCase
     /** @var MvcRouteListener */
     private $listener;
 
+    #[Override]
     public function setUp(): void
     {
         $this->events = new EventManager();


### PR DESCRIPTION
## Summary

Part of the post-8.5 cleanup cycle. **No version tag** — the cycle gets tagged once every repo is done.

## Tooling normalized

| tool | from | to |
| --- | --- | --- |
| `phpunit/phpunit` | `^10` | `^11.0 \|\| ^12.0 \|\| ^13.0` |
| `laminas/laminas-coding-standard` | `^3` | `^3.1` |

psalm was already at `^6.14`.

## The blocker: a non-static data provider

`ModuleTest::expectedListeners()` is now **static**. Non-static providers are deprecated in phpunit 10 and **removed in 12**, so this one blocked the bump outright. It read `$this` four ways, each with a static answer:

- `$this->prophesize(Request::class)->reveal()` and the `Response` equivalent → real `Laminas\Http\Request` / `Response` instances. Both are concrete with no required constructor arguments, so the doubles bought nothing a real object doesn't.
- `createServiceManager()` and `createApplication()` never touched `$this` → now `protected static`, called via `self::`.

`ProphecyTrait` stays — `testOnBootstrapReturnsEarlyForNonHttpEvents` still uses it, where an instance context is available.

## Removed phpunit APIs

| was | now | count |
| --- | --- | --- |
| `will($this->returnValue(...))` | `willReturn(...)` | 36 |
| `will($this->returnCallback(...))` | `willReturnCallback(...)` | 1 |

Both are **removed in phpunit 12**, so these were required, not cosmetic. One `returnValue` site spanned 14 lines, so the conversion tracked paren depth rather than matching a single line.

## Also

- 30 annotations → attributes across nine files (`@dataProvider`, `@depends`, `@group`).
- 53 `#[Override]` attributes, clearing every `MissingOverrideAttribute` entry from the psalm baseline — the largest count in the family.
- Removed the tracked `.coveralls.yml`; added `/.phpunit.cache/` to `.gitignore`.
- Added `.github/dependabot.yml` on a **monthly** interval.

## Verification

With `config.platform.php` unset, `--prefer-lowest` and latest on 8.2 and 8.5 — **188 tests, 541 assertions green on phpunit 11.5.50, 11.5.56 and 13.1.14**, with the same 2 mongo-extension skips throughout. psalm clean cold on the locked set; phpcs clean.

phpunit 13 still reports `any()` deprecations and mock-without-expectations notices — the `createMock` → `createStub` pass tracked separately. Neither fails the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated development tooling for newer PHPUnit releases and coding standards.
  * Added automated monthly dependency update configuration.
  * Improved compatibility with modern PHP language features and static analysis.
  * Excluded PHPUnit cache files from version control.

* **Tests**
  * Modernized test metadata and mocking APIs while preserving existing test coverage and behavior.
  * Removed obsolete static-analysis exceptions and legacy test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->