### PR TITLE
Use test stubs, and fix the types that assumed a stub is a mock

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1046,10 +1046,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationOAuth2AdapterFactoryTest]]></code>
     </ClassMustBeFinal>
-    <InvalidArgument>
-      <code><![CDATA[$this->services]]></code>
-      <code><![CDATA[$this->services]]></code>
-    </InvalidArgument>
   </file>
   <file src="test/Factory/DefaultAuthenticationListenerFactoryTest.php">
     <ClassMustBeFinal>
@@ -1093,9 +1089,6 @@
       <code><![CDATA[$server]]></code>
       <code><![CDATA[$server]]></code>
     </MixedAssignment>
-    <TooManyArguments>
-      <code><![CDATA[disableOriginalConstructor]]></code>
-    </TooManyArguments>
   </file>
   <file src="test/Factory/OAuth2ServerFactoryTest.php">
     <ClassMustBeFinal>
@@ -1118,9 +1111,6 @@
       <code><![CDATA[! $enabled]]></code>
       <code><![CDATA[$enabled]]></code>
     </RedundantCondition>
-    <TooManyArguments>
-      <code><![CDATA[disableOriginalConstructor]]></code>
-    </TooManyArguments>
   </file>
   <file src="test/Identity/AuthenticatedIdentityTest.php">
     <ClassMustBeFinal>

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -27,7 +27,7 @@ use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -45,7 +45,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /** @var AuthenticationService */
     protected $authentication;
 
-    /** @var AuthorizationInterface&MockObject */
+    /** @var AuthorizationInterface&Stub */
     protected $authorization;
 
     /** @var array */
@@ -67,7 +67,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->authentication = new AuthenticationService(new NonPersistent());
 
         // authorization service
-        $this->authorization = $this->getMockBuilder(AuthorizationInterface::class)->getMock();
+        $this->authorization = $this->createStub(AuthorizationInterface::class);
 
         // event for mvc and mvc-auth
         $this->request  = new HttpRequest();
@@ -222,10 +222,10 @@ class DefaultAuthenticationListenerTest extends TestCase
             'username' => 'user',
             'realm'    => 'User Area',
         ]);
-        $httpAuth->expects($this->any())
+        $httpAuth
             ->method('getBasicResolver')
             ->willReturn(false);
-        $httpAuth->expects($this->any())
+        $httpAuth
             ->method('getDigestResolver')
             ->willReturn(true);
         $httpAuth->expects($this->once())
@@ -350,7 +350,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             'username' => 'user',
             'realm'    => 'User Area',
         ]);
-        $httpAuth->expects($this->any())
+        $httpAuth
             ->method('getDigestResolver')
             ->willReturn(true);
         $httpAuth->expects($this->once())
@@ -526,10 +526,8 @@ class DefaultAuthenticationListenerTest extends TestCase
         callable $requestProvider
     ): void {
         $this->setupHttpBasicAuth();
-        // Minimal OAuth2 server mock, as we are not expecting any method calls
-        $server = $this->getMockBuilder(OAuth2Server::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        // Minimal OAuth2 server double, as we are not expecting any method calls
+        $server = $this->createStub(OAuth2Server::class);
         $this->listener->setOauth2Server($server);
 
         $routeMatch = $this->createRouteMatch(['controller' => $controller]);
@@ -545,16 +543,12 @@ class DefaultAuthenticationListenerTest extends TestCase
     #[Group('55')]
     public function testDoesNotPerformAuthenticationWhenMatchedControllerHasNoAuthMapEntryAndAuthSchemesAreDefined(): void
     {
-        // Minimal HTTP adapter mock, as we are not expecting any method calls
-        $httpAuth = $this->getMockBuilder(HttpAuth::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        // Minimal HTTP adapter double, as we are not expecting any method calls
+        $httpAuth = $this->createStub(HttpAuth::class);
         $this->listener->setHttpAdapter($httpAuth);
 
-        // Minimal OAuth2 server mock, as we are not expecting any method calls
-        $server = $this->getMockBuilder(OAuth2Server::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        // Minimal OAuth2 server double, as we are not expecting any method calls
+        $server = $this->createStub(OAuth2Server::class);
         $this->listener->setOauth2Server($server);
 
         $map = [
@@ -581,10 +575,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     #[Group('55')]
     public function testDoesNotPerformAuthenticationWhenMatchedControllerHasAuthMapEntryNotInDefinedAuthSchemes(): void
     {
-        // Minimal HTTP adapter mock, as we are not expecting any method calls
-        $httpAuth = $this->getMockBuilder(HttpAuth::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        // Minimal HTTP adapter double, as we are not expecting any method calls
+        $httpAuth = $this->createStub(HttpAuth::class);
         $this->listener->setHttpAdapter($httpAuth);
 
         // No OAuth2 server, intentionally
@@ -694,17 +686,14 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
             ->willReturn($types);
-        $adapter->expects($this->any())
+        $adapter
             ->method('getTypeFromRequest')
-            ->with($this->equalTo($request))
             ->willReturn('oauth2');
-        $adapter->expects($this->any())
+        $adapter->expects($this->atLeastOnce())
             ->method('matches')
             ->with($this->equalTo('oauth2'))
             ->willReturn(true);
-        $expected = $this->getMockBuilder(AuthenticatedIdentity::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $expected = $this->createStub(AuthenticatedIdentity::class);
         $adapter->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($request), $this->equalTo($this->response))
@@ -737,17 +726,14 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter1->expects($this->atLeastOnce())
             ->method('provides')
             ->willReturn($types);
-        $adapter1->expects($this->any())
+        $adapter1->expects($this->atLeastOnce())
             ->method('matches')
             ->with($this->equalTo('oauth2'))
             ->willReturn(true);
-        $adapter1->expects($this->any())
+        $adapter1
             ->method('getTypeFromRequest')
-            ->with($this->equalTo($request))
             ->willReturn('oauth2');
-        $expected = $this->getMockBuilder(AuthenticatedIdentity::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $expected = $this->createStub(AuthenticatedIdentity::class);
         $adapter1->expects($this->once())
             ->method('authenticate')
             ->with($this->equalTo($request), $this->equalTo($this->response))
@@ -759,9 +745,8 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter2->expects($this->atLeastOnce())
             ->method('provides')
             ->willReturn($types);
-        $adapter2->expects($this->any())
+        $adapter2
             ->method('getTypeFromRequest')
-            ->with($this->equalTo($request))
             ->willReturn('oauth2');
 
         $this->listener->attach($adapter1);
@@ -836,11 +821,10 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter->expects($this->atLeastOnce())
             ->method('provides')
             ->willReturn($types);
-        $adapter->expects($this->any())
+        $adapter
             ->method('getTypeFromRequest')
-            ->with($this->equalTo($request))
             ->willReturn('custom');
-        $adapter->expects($this->any())
+        $adapter->expects($this->atLeastOnce())
             ->method('matches')
             ->with($this->equalTo('custom'))
             ->willReturn(true);

--- a/test/Authentication/DefaultAuthenticationPostListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationPostListenerTest.php
@@ -13,7 +13,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\Response;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
 use Override;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DefaultAuthenticationPostListenerTest extends TestCase
@@ -21,7 +21,7 @@ class DefaultAuthenticationPostListenerTest extends TestCase
     protected DefaultAuthenticationPostListener $listener;
     protected MvcAuthEvent $mvcAuthEvent;
     protected TestAsset\AuthenticationService $authentication;
-    protected MockObject $authorization;
+    protected Stub $authorization;
 
     #[Override]
     public function setUp(): void
@@ -37,7 +37,7 @@ class DefaultAuthenticationPostListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent): MvcAuthEvent
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMockBuilder(AuthorizationInterface::class)->getMock();
+        $this->authorization  = $this->createStub(AuthorizationInterface::class);
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -41,7 +41,7 @@ class HttpAdapterTest extends TestCase
         $this->event = new MvcAuthEvent(
             $mvcEvent,
             $this->authentication,
-            $this->getMockBuilder(AuthorizationInterface::class)->getMock()
+            $this->createStub(AuthorizationInterface::class)
         );
     }
 

--- a/test/Authentication/OAuth2AdapterTest.php
+++ b/test/Authentication/OAuth2AdapterTest.php
@@ -63,9 +63,7 @@ class OAuth2AdapterTest extends TestCase
             ->method('getResponse')
             ->willReturn($oauth2Response);
 
-        $mvcAuthEvent = $this->getMockBuilder(MvcAuthEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mvcAuthEvent = $this->createStub(MvcAuthEvent::class);
 
         $result = $this->adapter->authenticate(new HttpRequest(), new HttpResponse(), $mvcAuthEvent);
         $this->assertInstanceOf(HttpResponse::class, $result);
@@ -105,9 +103,7 @@ class OAuth2AdapterTest extends TestCase
             ->method('getResponse')
             ->willReturn($oauth2Response);
 
-        $mvcAuthEvent = $this->getMockBuilder(MvcAuthEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mvcAuthEvent = $this->createStub(MvcAuthEvent::class);
 
         $result = $this->adapter->authenticate(new HttpRequest(), new HttpResponse(), $mvcAuthEvent);
         $this->assertInstanceOf(HttpResponse::class, $result);
@@ -142,9 +138,7 @@ class OAuth2AdapterTest extends TestCase
             ->method('getResponse')
             ->willReturn($oauth2Response);
 
-        $mvcAuthEvent = $this->getMockBuilder(MvcAuthEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mvcAuthEvent = $this->createStub(MvcAuthEvent::class);
 
         $result = $this->adapter->authenticate(new HttpRequest(), new HttpResponse(), $mvcAuthEvent);
         $this->assertInstanceOf(GuestIdentity::class, $result);
@@ -189,9 +183,7 @@ class OAuth2AdapterTest extends TestCase
             ->method('getResponse')
             ->willReturn($oauth2Response);
 
-        $mvcAuthEvent = $this->getMockBuilder(MvcAuthEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mvcAuthEvent = $this->createStub(MvcAuthEvent::class);
 
         $result = $this->adapter->authenticate(new HttpRequest(), new HttpResponse(), $mvcAuthEvent);
         $this->assertInstanceOf(HttpResponse::class, $result);

--- a/test/Authorization/DefaultAuthorizationPostListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationPostListenerTest.php
@@ -12,7 +12,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\Response;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
 use Override;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DefaultAuthorizationPostListenerTest extends TestCase
@@ -20,7 +20,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
     protected DefaultAuthorizationPostListener $listener;
     protected MvcAuthEvent $mvcAuthEvent;
     protected TestAsset\AuthenticationService $authentication;
-    protected MockObject $authorization;
+    protected Stub $authorization;
 
     #[Override]
     public function setUp(): void
@@ -36,7 +36,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent): MvcAuthEvent
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMockBuilder(AuthorizationInterface::class)->getMock();
+        $this->authorization  = $this->createStub(AuthorizationInterface::class);
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -13,7 +13,7 @@ use Laminas\Mvc\MvcEvent;
 use LaminasTest\ApiTools\MvcAuth\RouteMatchFactoryTrait;
 use LaminasTest\ApiTools\MvcAuth\TestAsset;
 use Override;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DefaultResourceResolverListenerTest extends TestCase
@@ -24,7 +24,7 @@ class DefaultResourceResolverListenerTest extends TestCase
     protected array $restControllers;
     protected MvcAuthEvent $mvcAuthEvent;
     protected TestAsset\AuthenticationService $authentication;
-    protected MockObject $authorization;
+    protected Stub $authorization;
 
     #[Override]
     public function setUp(): void
@@ -47,8 +47,7 @@ class DefaultResourceResolverListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent): MvcAuthEvent
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMockBuilder(AuthorizationInterface::class)
-            ->getMock();
+        $this->authorization  = $this->createStub(AuthorizationInterface::class);
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -95,7 +95,7 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
         $this->services->setService('config', $config);
         $this->services->setService(
             'authentication',
-            $this->getMockBuilder(AuthenticationService::class)->getMock()
+            $this->createStub(AuthenticationService::class)
         );
 
         $factory = $this->factory;

--- a/test/Factory/AuthenticationHttpAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationHttpAdapterFactoryTest.php
@@ -111,7 +111,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
     #[DataProvider('validConfiguration')]
     public function testCreatesHttpAdapterWhenConfigurationIsValid(array $options, array $provides): void
     {
-        $authService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+        $authService = $this->createStub(AuthenticationService::class);
         $this->services->expects($this->atLeastOnce())
             ->method('has')
             ->with($this->equalTo('authentication'))

--- a/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
+++ b/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
@@ -10,17 +10,17 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class AuthenticationOAuth2AdapterFactoryTest extends TestCase
 {
-    protected MockObject $services;
+    protected ServiceLocatorInterface&Stub $services;
 
     #[Override]
     public function setUp(): void
     {
-        $this->services = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
+        $this->services = $this->createStub(ServiceLocatorInterface::class);
     }
 
     /** @psalm-return array<string, array{0: array<array-key, mixed>}> */
@@ -50,6 +50,11 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
 
     public function testCreatesInstanceFromValidConfiguration(): void
     {
+        // This is the only test that asserts on how the factory queries the container,
+        // so it is the only one that needs a mock rather than the shared stub.
+        $services       = $this->createMock(ServiceLocatorInterface::class);
+        $this->services = $services;
+
         $config = [
             'adapter' => 'pdo',
             'storage' => [
@@ -58,7 +63,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
             ],
         ];
 
-        $this->services->expects($this->any())
+        $services->expects($this->atLeastOnce())
             ->method('get')
             ->with($this->stringContains('Config'))
             ->willReturn([

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -43,7 +43,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCreatingOAuth2ServerFromStorageService(): void
     {
-        $adapter = $this->getMockBuilder(PdoStorage::class)->disableOriginalConstructor()->getMock();
+        $adapter = $this->createStub(PdoStorage::class);
 
         $this->services->setService('TestAdapter', $adapter);
         $this->services->setService('config', [
@@ -189,7 +189,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithBasicSchemeAndHtpasswdValueReturnsListenerWithHttpAdapter(): void
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
+        $authenticationService = $this->createStub(AuthenticationServiceInterface::class);
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [
@@ -213,7 +213,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithDigestSchemeAndHtdigestValueReturnsListenerWithHttpAdapter(): void
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
+        $authenticationService = $this->createStub(AuthenticationServiceInterface::class);
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [
@@ -237,7 +237,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithCustomAuthenticationTypesReturnsListenerComposingThem(): void
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
+        $authenticationService = $this->createStub(AuthenticationServiceInterface::class);
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [
@@ -265,14 +265,14 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
     public function testFactoryWillUsePreconfiguredOAuth2ServerInstanceProvidedByLaminasOAuth2(): void
     {
         // Configure mock OAuth2 Server
-        $oauth2Server = $this->getMockBuilder(OAuth2Server::class)->disableOriginalConstructor()->getMock();
+        $oauth2Server = $this->createStub(OAuth2Server::class);
         // Wrap it in a factory
         $this->services->setService('Laminas\ApiTools\OAuth2\Service\OAuth2Server', function () use ($oauth2Server) {
             return $oauth2Server;
         });
 
         // Configure mock OAuth2 Server storage adapter
-        $adapter = $this->getMockBuilder(PdoStorage::class)->disableOriginalConstructor()->getMock();
+        $adapter = $this->createStub(PdoStorage::class);
 
         $this->services->setService('TestAdapter', $adapter);
         $this->services->setService('config', [
@@ -299,7 +299,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithAuthenticationMapReturnsListenerComposingMap(): void
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
+        $authenticationService = $this->createStub(AuthenticationServiceInterface::class);
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -191,7 +191,7 @@ class HttpAdapterFactoryTest extends TestCase
             ->with($keyForServiceManager)
             ->willReturn(true);
 
-        $resolver = $this->getMockBuilder(ResolverInterface::class)->getMock();
+        $resolver = $this->createStub(ResolverInterface::class);
         $serviceManager
             ->expects($this->once())
             ->method('get')
@@ -223,7 +223,7 @@ class HttpAdapterFactoryTest extends TestCase
             ->with($keyForServiceManager)
             ->willReturn(true);
 
-        $resolver = $this->getMockBuilder(ResolverInterface::class)->getMock();
+        $resolver = $this->createStub(ResolverInterface::class);
         $serviceManager
             ->expects($this->once())
             ->method('get')
@@ -285,7 +285,7 @@ class HttpAdapterFactoryTest extends TestCase
 
         $serviceManager = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
         $serviceManager
-            ->expects($this->any())
+            ->expects($this->atLeastOnce())
             ->method('has')
             ->with($missingKeyForServiceManager)
             ->willReturn(false);

--- a/test/Factory/NamedOAuth2ServerFactoryTest.php
+++ b/test/Factory/NamedOAuth2ServerFactoryTest.php
@@ -59,9 +59,7 @@ class NamedOAuth2ServerFactoryTest extends TestCase
             ],
         ]);
 
-        $oauth2StorageAdapter = $this->getMockBuilder(MemoryStorage::class)
-            ->disableOriginalConstructor(true)
-            ->getMock();
+        $oauth2StorageAdapter = $this->createStub(MemoryStorage::class);
 
         $services->setService(
             'LaminasTest\ApiTools\OAuth2\TestAsset\MockAdapter',

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -95,9 +95,7 @@ class OAuth2ServerFactoryTest extends TestCase
         }
 
         $services    = $this->mockConfig(new ServiceManager());
-        $mongoClient = $this->getMockBuilder(MongoDB::class)
-            ->disableOriginalConstructor(true)
-            ->getMock();
+        $mongoClient = $this->createStub(MongoDB::class);
         $services->setService('MongoService', $mongoClient);
 
         $config = [

--- a/test/Identity/IdentityPluginTest.php
+++ b/test/Identity/IdentityPluginTest.php
@@ -22,8 +22,8 @@ class IdentityPluginTest extends TestCase
     {
         $this->event = $event = new MvcEvent();
 
-        $controller = $this->getMockBuilder(AbstractController::class)->getMock();
-        $controller->expects($this->any())
+        $controller = $this->createStub(AbstractController::class);
+        $controller
             ->method('getEvent')
             ->willReturnCallback(function () use ($event) {
                 return $event;

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -11,17 +11,17 @@ use Laminas\EventManager\EventManager;
 use Laminas\EventManager\Test\EventListenerIntrospectionTrait;
 use Laminas\Mvc\MvcEvent;
 use Override;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class MvcRouteListenerTest extends TestCase
 {
     use EventListenerIntrospectionTrait;
 
-    /** @var AuthenticationService&MockObject */
+    /** @var AuthenticationService&Stub */
     private $auth;
 
-    /** @var MvcAuthEvent&MockObject */
+    /** @var MvcAuthEvent&Stub */
     private $event;
 
     /** @var EventManager */
@@ -34,14 +34,8 @@ class MvcRouteListenerTest extends TestCase
     public function setUp(): void
     {
         $this->events = new EventManager();
-        $this->auth   = $this
-            ->getMockBuilder(AuthenticationService::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->event  = $this
-            ->getMockBuilder(MvcAuthEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->auth   = $this->createStub(AuthenticationService::class);
+        $this->event  = $this->createStub(MvcAuthEvent::class);
 
         $this->listener = new MvcRouteListener(
             $this->event,


### PR DESCRIPTION
## Summary

Part of the **mock-to-stub pass**, and the largest of them — this repo had the highest count in the family. **No version tag.**

## `any()` — 13 sites

Deprecated for removal in phpunit 14. **Nine** carried a `with*()` constraint and became `atLeastOnce()`, which keeps the argument assertions — a `with()` constraint is checked on every matching call, so dropping it silently costs assertions. The other **four** had no constraint, so the `expects()` call simply went.

## Thirty doubles become stubs

Chosen by whether `expects()` is ever called on that variable, not by pattern-matching `createMock`. Nine test files contain no `expects()` at all.

Four were flagged by their **own comments** — *"Minimal OAuth2 server mock, as we are not expecting any method calls"* and the HTTP adapter equivalent. That is exactly what a stub is.

## Three dead expectations

Three tests failed with `Expected invocation at least once but it never occurred` on `getTypeFromRequest`. Each sets an explicit **auth map**, so the listener resolves the type from the map and never asks the adapter.

The configured return is kept, but the count and the constraint are dropped — neither could ever be satisfied, and `with()` without `expects()` is the phpunit 14 removal.

## The interesting failure: 14 TypeErrors, phpunit 12+ only

```
Cannot assign TestStub_AuthorizationInterface_… to property …$authorization
of type PHPUnit\Framework\MockObject\MockObject
```

**phpunit 12 stopped making stubs `MockObject` instances**, so every declaration that now receives a `createStub()` result has to say `Stub`. Four properties were affected — three of them **native property types** rather than docblocks, which is why phpunit 11 stayed silent and 13 failed hard.

Worth knowing for any repo doing this conversion.

## One restructure

`AuthenticationOAuth2AdapterFactoryTest` needed what `rpc` needed: its container was built in `setUp`, but only `testCreatesInstanceFromValidConfiguration` asserts on it. `setUp` now builds a stub, and that one test builds its own mock.

## Result

188 tests / 542 assertions pass with **no issues at all** on 11.5.56 and 13.1.14, where 13 previously reported **11 deprecations and 89 notices**. Assertions are up by one, not down. Baseline regenerated cold on 8.2 with the committed lock; psalm and phpcs clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and clarity by using dedicated stubs for dependencies that do not require interaction verification.
  * Retained and strengthened explicit expectations where behavior is actively verified.
  * Removed obsolete static-analysis suppressions after updating test doubles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->