### PR TITLE
Remove the ServiceManager v2 surface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -229,9 +229,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AclAuthorizationFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[AclAuthorizationFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$action]]></code>
       <code><![CDATA[$methods]]></code>
@@ -256,23 +253,14 @@
     <MixedReturnStatement>
       <code><![CDATA[$config['api-tools-mvc-auth']['authorization']]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Factory/ApacheResolverFactory.php">
     <ClassMustBeFinal>
       <code><![CDATA[ApacheResolverFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[ApacheResolverFactory]]></code>
-    </DeprecatedInterface>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[false|ApacheResolver]]></code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgument>
-      <code><![CDATA[ApacheResolver::class]]></code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$config['api-tools-mvc-auth']]]></code>
       <code><![CDATA[$config['api-tools-mvc-auth']['authentication']]]></code>
@@ -286,15 +274,10 @@
     <MixedReturnStatement>
       <code><![CDATA[new ApacheResolver($htpasswd)]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <UndefinedClass>
-      <code><![CDATA[ApacheResolver]]></code>
       <code><![CDATA[ApacheResolver]]></code>
     </UndefinedClass>
     <UndefinedDocblockClass>
-      <code><![CDATA[false|ApacheResolver]]></code>
       <code><![CDATA[false|ApacheResolver]]></code>
     </UndefinedDocblockClass>
   </file>
@@ -302,9 +285,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationAdapterDelegatorFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[AuthenticationAdapterDelegatorFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$data]]></code>
       <code><![CDATA[$listener]]></code>
@@ -326,9 +306,6 @@
       <code><![CDATA[$listener]]></code>
       <code><![CDATA[$listener]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Factory/AuthenticationHttpAdapterFactory.php">
     <MixedArgument>
@@ -353,23 +330,14 @@
     <ClassMustBeFinal>
       <code><![CDATA[AuthenticationServiceFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[AuthenticationServiceFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$container->get(NonPersistent::class)]]></code>
     </MixedArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Factory/DefaultAuthHttpAdapterFactory.php">
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthHttpAdapterFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[DefaultAuthHttpAdapterFactory]]></code>
-    </DeprecatedInterface>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[HttpAuth|false]]></code>
     </ImplementedReturnTypeMismatch>
@@ -384,17 +352,11 @@
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Factory/DefaultAuthenticationListenerFactory.php">
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthenticationListenerFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[DefaultAuthenticationListenerFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$authService]]></code>
       <code><![CDATA[$config['api-tools-oauth2']['storage']]]></code>
@@ -429,9 +391,6 @@
       <code><![CDATA[$config['api-tools-mvc-auth']['authentication']['map']]]></code>
       <code><![CDATA[$config['api-tools-mvc-auth']['authentication']['types']]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$authenticationTypes]]></code>
     </RiskyTruthyFalsyComparison>
@@ -446,9 +405,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[DefaultAuthorizationListenerFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[DefaultAuthorizationListenerFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$authorization]]></code>
       <code><![CDATA[\ZF\MvcAuth\Authorization\AuthorizationInterface::class]]></code>
@@ -457,9 +413,6 @@
     <MixedAssignment>
       <code><![CDATA[$authorization]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <UndefinedClass>
       <code><![CDATA[\ZF\MvcAuth\Authorization\AuthorizationInterface]]></code>
       <code><![CDATA[\ZF\MvcAuth\Authorization\AuthorizationInterface]]></code>
@@ -469,9 +422,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[DefaultResourceResolverListenerFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[DefaultResourceResolverListenerFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
     </MixedArgument>
@@ -487,9 +437,6 @@
       <code><![CDATA[$restConfig]]></code>
       <code><![CDATA[$restServices[$controllerService]]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <PossiblyUnusedProperty>
       <code><![CDATA[$httpMethods]]></code>
     </PossiblyUnusedProperty>
@@ -498,9 +445,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[FileResolverFactory]]></code>
     </ClassMustBeFinal>
-    <DeprecatedInterface>
-      <code><![CDATA[FileResolverFactory]]></code>
-    </DeprecatedInterface>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[false|FileResolver]]></code>
     </ImplementedReturnTypeMismatch>
@@ -517,9 +461,6 @@
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$htdigest]]></code>
     </MixedAssignment>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/Factory/HttpAdapterFactory.php">
     <MixedArgument>

--- a/src/Factory/AclAuthorizationFactory.php
+++ b/src/Factory/AclAuthorizationFactory.php
@@ -7,8 +7,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 use Laminas\ApiTools\MvcAuth\Authorization\AclAuthorization;
 use Laminas\ApiTools\MvcAuth\Authorization\AclAuthorizationFactory as AclFactory;
 use Laminas\Http\Request;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -44,19 +43,6 @@ class AclAuthorizationFactory implements FactoryInterface
     {
         $config = $this->getConfigFromContainer($container);
         return $this->createAclFromConfig($config);
-    }
-
-    /**
-     * Create the AclAuthorization (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return AclAuthorization
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, AclAuthorization::class);
     }
 
     /**

--- a/src/Factory/ApacheResolverFactory.php
+++ b/src/Factory/ApacheResolverFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\MvcAuth\Factory;
 
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -36,18 +35,5 @@ class ApacheResolverFactory implements FactoryInterface
         $htpasswd = $config['api-tools-mvc-auth']['authentication']['http']['htpasswd'];
 
         return new ApacheResolver($htpasswd);
-    }
-
-    /**
-     * Create and return an ApacheResolve instance (v2).
-     *
-     * Exists for backwards compatibility only; proxies to __invoke().
-     *
-     * @return false|ApacheResolver
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, ApacheResolver::class);
     }
 }

--- a/src/Factory/AuthenticationAdapterDelegatorFactory.php
+++ b/src/Factory/AuthenticationAdapterDelegatorFactory.php
@@ -7,8 +7,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 use Laminas\ApiTools\MvcAuth\Authentication\DefaultAuthenticationListener;
 use Laminas\ApiTools\MvcAuth\Authentication\HttpAdapter;
 use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
-use Laminas\ServiceManager\DelegatorFactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -44,22 +43,6 @@ class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
         }
 
         return $listener;
-    }
-
-    /**
-     * Decorate the DefaultAuthenticationListener (v2)
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @param string $name
-     * @param string $requestedName
-     * @param callable $callback
-     * @return DefaultAuthenticationListener
-     */
-    #[Override]
-    public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)
-    {
-        return $this($container, $requestedName, $callback);
     }
 
     /**

--- a/src/Factory/AuthenticationServiceFactory.php
+++ b/src/Factory/AuthenticationServiceFactory.php
@@ -6,8 +6,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\Storage\NonPersistent;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -24,18 +23,5 @@ class AuthenticationServiceFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new AuthenticationService($container->get(NonPersistent::class));
-    }
-
-    /**
-     * Create and return an AuthenticationService instance (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return AuthenticationService
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, AuthenticationService::class);
     }
 }

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Factory;
 
 use Laminas\Authentication\Adapter\Http as HttpAuth;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -38,18 +37,5 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
         }
 
         return HttpAdapterFactory::factory($config['api-tools-mvc-auth']['authentication']['http'], $container);
-    }
-
-    /**
-     * Create and return an HTTP authentication adapter instance (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return HttpAuth|false
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, HttpAuth::class);
     }
 }

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -8,8 +8,7 @@ use Laminas\ApiTools\MvcAuth\Authentication\DefaultAuthenticationListener;
 use Laminas\ApiTools\MvcAuth\Authentication\HttpAdapter;
 use Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter;
 use Laminas\ApiTools\OAuth2\Factory\OAuth2ServerFactory as LaminasOAuth2ServerFactory;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
@@ -53,19 +52,6 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
         $listener->setAuthMap($this->getAuthenticationMap($container));
 
         return $listener;
-    }
-
-    /**
-     * Create and return a DefaultAuthenticationListener (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return DefaultAuthenticationListener
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DefaultAuthenticationListener::class);
     }
 
     /**

--- a/src/Factory/DefaultAuthorizationListenerFactory.php
+++ b/src/Factory/DefaultAuthorizationListenerFactory.php
@@ -7,8 +7,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 use Laminas\ApiTools\MvcAuth\Authorization\AuthorizationInterface;
 use Laminas\ApiTools\MvcAuth\Authorization\DefaultAuthorizationListener;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -46,18 +45,5 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
             : $container->get(\ZF\MvcAuth\Authorization\AuthorizationInterface::class);
 
         return new DefaultAuthorizationListener($authorization);
-    }
-
-    /**
-     * Create and return the default authorization listener (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return DefaultAuthorizationListener
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DefaultAuthorizationListener::class);
     }
 }

--- a/src/Factory/DefaultResourceResolverListenerFactory.php
+++ b/src/Factory/DefaultResourceResolverListenerFactory.php
@@ -6,8 +6,7 @@ namespace Laminas\ApiTools\MvcAuth\Factory;
 
 use Laminas\ApiTools\MvcAuth\Authorization\DefaultResourceResolverListener;
 use Laminas\Http\Request;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -40,19 +39,6 @@ class DefaultResourceResolverListenerFactory implements FactoryInterface
         return new DefaultResourceResolverListener(
             $this->getRestServicesFromConfig($config)
         );
-    }
-
-    /**
-     * Create and return a DefaultResourceResolverListener instance (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return DefaultResourceResolverListener
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DefaultResourceResolverListener::class);
     }
 
     /**

--- a/src/Factory/FileResolverFactory.php
+++ b/src/Factory/FileResolverFactory.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Factory;
 
 use Laminas\Authentication\Adapter\Http\FileResolver;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
 use Psr\Container\ContainerInterface;
 
@@ -35,18 +34,5 @@ class FileResolverFactory implements FactoryInterface
         $htdigest = $config['api-tools-mvc-auth']['authentication']['http']['htdigest'];
 
         return new FileResolver($htdigest);
-    }
-
-    /**
-     * Create and return a FileResolver instance, if configured (v2).
-     *
-     * Provided for backwards compatibility; proxies to __invoke().
-     *
-     * @return false|FileResolver
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, FileResolver::class);
     }
 }


### PR DESCRIPTION
## Summary

Second repo in the SM v2 removal, and the largest surface in the family.

> ⚠️ **BC break.** `createService()` and `createDelegatorWithName()` were public, so the next release from this line is a **major**.

## What went

Nine classes drop their v2 compatibility method:

| | method |
| --- | --- |
| 8 factories | `createService(ServiceLocatorInterface $container)` |
| `AuthenticationAdapterDelegatorFactory` | `createDelegatorWithName(...)` |

Each was a **two-line proxy to the v3 `__invoke()` that already exists alongside it**, so no behaviour moves. The interfaces move with them:

```
Laminas\ServiceManager\FactoryInterface           →  …\Factory\FactoryInterface
Laminas\ServiceManager\DelegatorFactoryInterface  →  …\Factory\DelegatorFactoryInterface
```

## This is the migration the interface prescribes for itself

The deprecated v2 `FactoryInterface` exists in servicemanager 3 purely as an extension of the v3 one that adds `createService()`. Its own docblock says:

> Once you have tested your code, you can then update your class to only implement `Laminas\ServiceManager\Factory\FactoryInterface`, and remove the `createService()` method.

## Two things deliberately left alone

- **`Laminas\ServiceManager\ServiceLocatorInterface` is not a v2 artefact** — it still exists in v3. The import was dropped only where nothing else in the file referenced it, which leaves `src/Module.php` untouched, where `getContainer()` legitimately returns one.
- **No `container-interop` here**, unlike content-negotiation — every `__invoke()` already types its container as `Psr\Container\ContainerInterface`.

## Nothing internal used the v2 API

`config/` registers these as ordinary v3 factories and delegators, and no test calls `createService()` or `createDelegatorWithName()`.

## Verification

**188 tests, 542 assertions green on phpunit 11.5.50 through 13.1.14, across 8.2 and 8.5** — unchanged from before. psalm and phpcs clean on the locked set; baseline regenerated cold on 8.2.

`9 files changed, 9 insertions(+), 138 deletions(-)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication, authorization, resource, and file resolver factories to use the modern factory interface.
  * Removed deprecated factory compatibility methods; factory creation continues through the current invocation mechanism.
  * Updated delegator factory integration to use the modern interface and removed its legacy compatibility method.

* **Chores**
  * Cleaned up obsolete static-analysis suppressions and duplicate diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->