### PR TITLE
Add native return types where psalm reports them missing

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1084,9 +1084,6 @@
     <InvalidDocblock>
       <code><![CDATA[public static function expectedListeners(): array]]></code>
     </InvalidDocblock>
-    <MismatchingDocblockParamType>
-      <code><![CDATA[callable(MvcEvent|MvcAuthEvent):null|Response]]></code>
-    </MismatchingDocblockParamType>
     <MixedArgument>
       <code><![CDATA[$config['service_manager']]]></code>
       <code><![CDATA[$config['service_manager']]]></code>
@@ -1105,9 +1102,6 @@
      *     3: EventManager
      * }>]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$listener]]></code>
-    </PossiblyInvalidArgument>
     <UndefinedMagicMethod>
       <code><![CDATA[getRequest]]></code>
     </UndefinedMagicMethod>

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -118,7 +118,7 @@ class ModuleTest extends TestCase
     }
 
     /**
-     * @psalm-param callable(MvcEvent|MvcAuthEvent):null|Response $listener
+     * @psalm-param callable(MvcEvent|MvcAuthEvent):(null|Response) $listener
      * @psalm-param MvcEvent::EVENT_*|MvcAuthEvent::EVENT_* $event
      */
     #[DataProvider('expectedListeners')]


### PR DESCRIPTION
## Summary

Part of the native-types pass (backlog §4b), driven by psalm's own messages — it names the type it infers, so nothing here is a guess. Only types with an unambiguous native spelling were applied.

One annotation fixed, in test/ModuleTest.php. The parameter was documented as

  @psalm-param callable(MvcEvent|MvcAuthEvent):null|Response $listener

which psalm reads as "a callable returning null" OR "a Response", because the trailing
union binds outside the callable rather than to its return type. That contradicted the
native `callable`. Parenthesised to :(null|Response), which is what was meant.

This annotation stays rather than being replaced by a native type: a callable's signature
is not expressible in PHP's type system, which is exactly the kind of docblock this pass
keeps.

## Scope

**Return types only.** Parameter types are the BC-dangerous half — adding one where a parent or interface declared none makes an override *narrower*, which PHP rejects — and they need more judgement, so they are a separate decision.

Annotations carrying information the type system cannot express (array shapes, generics, callable signatures, `class-string`) are kept.

## Verification

Suite green on the floor PHP with the committed lock and on 8.5; phpcs clean; psalm baseline regenerated cold, with the relevant entries now gone.

> ⚠️ **BC break.** Adding a return type to a non-final public or protected method requires subclasses to declare a compatible one. This line is already major for other reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis accuracy for test listener response handling.
  * Removed obsolete analysis suppressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->