### PR TITLE
Allow laminas-http 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laminas-api-tools/api-tools-oauth2": "^1.11",
         "laminas/laminas-authentication": "^2.19",
         "laminas/laminas-eventmanager": "^3.15",
-        "laminas/laminas-http": "^2.23",
+        "laminas/laminas-http": "^2.23 || ^3.0",
         "laminas/laminas-modulemanager": "^2.19",
         "laminas/laminas-mvc": "^3.8",
         "laminas/laminas-permissions-acl": "^2.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34bfdaefc120c2d68dfffa4ddebce9a9",
+    "content-hash": "62be544f018195def71383aa6c3b2c5e",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
## Summary

laminas-http 3 drops the abandoned **`laminas/laminas-loader`**, replacing `Laminas\Loader\PluginClassLocator` with a self-contained `Laminas\Http\HeaderLoader`. Upstream wrote that change but never released it; [`datasage/laminas-http` 3.0.0](https://github.com/datasage/laminas-http/releases/tag/3.0.0) tags it.

## Why widen rather than move to it

Composer honours a `repositories` entry **only in the root package**, so this repository's own CI still resolves *upstream* laminas-http, which has no 3.x release. The range therefore picks 2.23.x here and nothing changes — verified, the lock still resolves 2.23.0 and the suite is unchanged.

It's the **root application**, which does carry the `repositories` entry, that can then resolve 3.0.0.

## Safe for this package

laminas-http 3's breaking changes are confined to `Headers`:

- `setPluginClassLoader()` narrows its parameter from `PluginClassLocator` to `HeaderLoader`
- `getPluginClassLoader()` gains a declared return type
- `$pluginClassLoader` changes from `protected` to `private`, which breaks subclasses

Nothing here references that API or extends `Headers` — checked across all sixteen forks plus the consuming applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compatibility requirements to support both major versions 2 and 3 of the HTTP component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
