### PR TITLE
Remove the OAuth2 Mongo storage adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,21 +227,6 @@ return [
                         ],
                     ],
                 ],
-                'client' => [
-                    // This defines an OAuth2 adapter backed by Mongo.
-                    'adapter' => 'Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => [
-                        'adapter' => 'mongo',
-                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
-                        'dsn' => 'mongodb://localhost',
-                        'database' => 'oauth2',
-                        'options' => [
-                            'username' => 'username',
-                            'password' => 'password',
-                            'connectTimeoutMS' => 500,
-                        ],
-                    ],
-                ],
             ],
         ],
     ],
@@ -631,21 +616,6 @@ return [
                         'password' => 'password',
                         'options' => [
                             1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
-                        ],
-                    ],
-                ],
-                'client' => [
-                    // This defines an OAuth2 adapter backed by Mongo.
-                    'adapter' => 'Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => [
-                        'adapter' => 'mongo',
-                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
-                        'dsn' => 'mongodb://localhost',
-                        'database' => 'oauth2',
-                        'options' => [
-                            'username' => 'username',
-                            'password' => 'password',
-                            'connectTimeoutMS' => 500,
                         ],
                     ],
                 ],

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -107,9 +107,9 @@ return [
              *
              * - Specify a "storage" subkey pointing to a named service or an array
              *   of named services to use.
-             * - Specify an "adapter" subkey with the value "pdo" or "mongo", and
+             * - Specify an "adapter" subkey with the value "pdo", and
              *   include additional subkeys for configuring a Laminas\ApiTools\OAuth2\Adapter\PdoAdapter
-             *   or Laminas\ApiTools\OAuth2\Adapter\MongoAdapter, accordingly. See the api-tools-oauth2
+             *   accordingly. See the api-tools-oauth2
              *   documentation for details.
              *
              * This looks like the following for the HTTP basic/digest and OAuth2
@@ -142,22 +142,6 @@ return [
                         'password' => 'password',
                         'options' => [
                             1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
-                        ],
-                    ],
-                ],
-                // OAuth2 adapter, using an "adapter" type of "mongo"
-                'client' => [
-                    'adapter' => 'Laminas\ApiTools\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => [
-                        'adapter' => 'mongo',
-                        'route' => '/client',
-                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
-                        'dsn' => 'mongodb://localhost',
-                        'database' => 'oauth2',
-                        'options' => [
-                            'username' => 'username',
-                            'password' => 'password',
-                            'connectTimeoutMS' => 500,
                         ],
                     ],
                 ],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -549,14 +549,12 @@
       <code><![CDATA[$server->getStorage('user_credentials')]]></code>
     </ArgumentTypeCoercion>
     <InvalidArgument>
-      <code><![CDATA[self::createMongoDatabase($config, $container)]]></code>
       <code><![CDATA[self::createPdoConfig($config)]]></code>
     </InvalidArgument>
     <InvalidCast>
       <code><![CDATA[self::createPdoConfig($config)]]></code>
     </InvalidCast>
     <MixedArgument>
-      <code><![CDATA[$dbLocatorName]]></code>
       <code><![CDATA[$oauth2Config]]></code>
       <code><![CDATA[$oauth2Config['grant_types']]]></code>
       <code><![CDATA[$options]]></code>
@@ -568,48 +566,30 @@
     <MixedArrayAccess>
       <code><![CDATA[$allConfig['api-tools-oauth2']]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$options['connect']]]></code>
-    </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$accessLifetime]]></code>
       <code><![CDATA[$allConfig]]></code>
       <code><![CDATA[$allowImplicit]]></code>
       <code><![CDATA[$audience]]></code>
       <code><![CDATA[$clientOptions['allow_credentials_in_request_body']]]></code>
-      <code><![CDATA[$dbLocatorName]]></code>
       <code><![CDATA[$enforceState]]></code>
-      <code><![CDATA[$mongo]]></code>
       <code><![CDATA[$oauth2Config]]></code>
-      <code><![CDATA[$options]]></code>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$options]]></code>
       <code><![CDATA[$password]]></code>
       <code><![CDATA[$refreshOptions['always_issue_new_refresh_token']]]></code>
       <code><![CDATA[$refreshOptions['refresh_token_lifetime']]]></code>
       <code><![CDATA[$refreshOptions['unset_refresh_token_after_use']]]></code>
-      <code><![CDATA[$server]]></code>
       <code><![CDATA[$storage[$key]]]></code>
       <code><![CDATA[$username]]></code>
     </MixedAssignment>
-    <MixedPropertyFetch>
-      <code><![CDATA[$mongo->{$config['database']}]]></code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement>
-      <code><![CDATA[$container->get($dbLocatorName)]]></code>
-      <code><![CDATA[$mongo->{$config['database']}]]></code>
-    </MixedReturnStatement>
     <PossiblyNullArgument>
       <code><![CDATA[$server->getStorage('client_credentials')]]></code>
       <code><![CDATA[$server->getStorage('jwt_bearer')]]></code>
       <code><![CDATA[$server->getStorage('refresh_token')]]></code>
       <code><![CDATA[$server->getStorage('user_credentials')]]></code>
     </PossiblyNullArgument>
-    <UndefinedClass>
-      <code><![CDATA[MongoClient]]></code>
-    </UndefinedClass>
     <UndefinedDocblockClass>
-      <code><![CDATA[MongoDB]]></code>
       <code><![CDATA[array|ArrayAccess]]></code>
     </UndefinedDocblockClass>
     <UnusedConstructor>

--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\MvcAuth\Factory;
 
-use Laminas\ApiTools\OAuth2\Adapter\MongoAdapter;
 use Laminas\ApiTools\OAuth2\Adapter\PdoAdapter;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use MongoClient;
-use MongoDB;
 use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\GrantType\ClientCredentials;
 use OAuth2\GrantType\JwtBearer;
@@ -55,12 +52,12 @@ final class OAuth2ServerFactory
     /**
      * Create and return an OAuth2 storage adapter instance.
      *
-     * @return array|MongoAdapter|PdoAdapter A PdoAdapter, MongoAdapter, or array of storage instances.
+     * @return array|PdoAdapter A PdoAdapter or array of storage instances.
      */
     private static function createStorage(array $config, ContainerInterface $container)
     {
         if (isset($config['adapter']) && is_string($config['adapter'])) {
-            return self::createStorageFromAdapter($config['adapter'], $config, $container);
+            return self::createStorageFromAdapter($config['adapter'], $config);
         }
 
         if (
@@ -76,16 +73,14 @@ final class OAuth2ServerFactory
     /**
      * Create an OAuth2 storage instance based on the adapter specified.
      *
-     * @param string $adapter One of "pdo" or "mongo".
-     * @return MongoAdapter|PdoAdapter
+     * @param string $adapter Must be "pdo".
+     * @return PdoAdapter
      */
-    private static function createStorageFromAdapter(string $adapter, array $config, ContainerInterface $container)
+    private static function createStorageFromAdapter(string $adapter, array $config)
     {
         switch (strtolower($adapter)) {
             case 'pdo':
                 return self::createPdoAdapter($config);
-            case 'mongo':
-                return self::createMongoAdapter($config, $container);
             default:
                 throw new ServiceNotCreatedException('Invalid storage adapter type for OAuth2');
         }
@@ -130,19 +125,6 @@ final class OAuth2ServerFactory
     }
 
     /**
-     * Create and return an OAuth2 Mongo adapter.
-     *
-     * @return MongoAdapter
-     */
-    private static function createMongoAdapter(array $config, ContainerInterface $container)
-    {
-        return new MongoAdapter(
-            self::createMongoDatabase($config, $container),
-            self::getOAuth2ServerConfig($config)
-        );
-    }
-
-    /**
      * Create and return the configuration needed to create a PDO instance.
      *
      * @return array
@@ -165,32 +147,6 @@ final class OAuth2ServerFactory
             'password' => $password,
             'options'  => $options,
         ];
-    }
-
-    /**
-     * Create and return a Mongo database instance.
-     *
-     * @return MongoDB
-     */
-    private static function createMongoDatabase(array $config, ContainerInterface $container)
-    {
-        $dbLocatorName = $config['locator_name'] ?? 'MongoDB';
-
-        if ($container->has($dbLocatorName)) {
-            return $container->get($dbLocatorName);
-        }
-
-        if (! isset($config['database'])) {
-            throw new ServiceNotCreatedException(
-                'Missing OAuth2 Mongo database configuration'
-            );
-        }
-
-        $options            = $config['options'] ?? [];
-        $options['connect'] = false;
-        $server             = $config['dsn'] ?? null;
-        $mongo              = new MongoClient($server, $options);
-        return $mongo->{$config['database']};
     }
 
     /**

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -7,7 +7,6 @@ namespace LaminasTest\ApiTools\MvcAuth\Factory;
 use Laminas\ApiTools\MvcAuth\Factory\OAuth2ServerFactory;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\ServiceManager;
-use MongoDB;
 use OAuth2\GrantType;
 use OAuth2\OpenID\GrantType\AuthorizationCode as OpenIDAuthorizationCodeGrantType;
 use OAuth2\Server as OAuth2Server;
@@ -16,7 +15,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
-use function class_exists;
 use function sprintf;
 
 class OAuth2ServerFactoryTest extends TestCase
@@ -88,50 +86,14 @@ class OAuth2ServerFactoryTest extends TestCase
         $this->assertInstanceOf(OAuth2Server::class, $server);
     }
 
-    public function testCanCreateMongoBackedServerUsingMongoFromServices(): void
-    {
-        if (! class_exists(MongoDB::class)) {
-            $this->markTestSkipped('Mongo extension is required for this test');
-        }
-
-        $services    = $this->mockConfig(new ServiceManager());
-        $mongoClient = $this->createStub(MongoDB::class);
-        $services->setService('MongoService', $mongoClient);
-
-        $config = [
-            'adapter'      => 'mongo',
-            'locator_name' => 'MongoService',
-        ];
-        $server = OAuth2ServerFactory::factory($config, $services);
-        $this->assertInstanceOf(OAuth2Server::class, $server);
-    }
-
-    public function testRaisesExceptionCreatingMongoBackedServerIfDatabaseIsMissing(): void
+    public function testMongoIsNoLongerAValidStorageAdapter(): void
     {
         $services = $this->mockConfig(new ServiceManager());
-        $config   = [
-            'adapter' => 'mongo',
-        ];
 
         $this->expectException(ServiceNotCreatedException::class);
-        $this->expectExceptionMessage('database');
+        $this->expectExceptionMessage('Invalid storage adapter type for OAuth2');
 
-        OAuth2ServerFactory::factory($config, $services);
-    }
-
-    public function testCanCreateMongoAdapterBackedServer(): void
-    {
-        if (! class_exists(MongoDB::class)) {
-            $this->markTestSkipped('Mongo extension is required for this test');
-        }
-
-        $services = $this->mockConfig(new ServiceManager());
-        $config   = [
-            'adapter'  => 'mongo',
-            'database' => 'api-tools-mvc-auth-test',
-        ];
-        $server   = OAuth2ServerFactory::factory($config, $services);
-        $this->assertInstanceOf(OAuth2Server::class, $server);
+        OAuth2ServerFactory::factory(['adapter' => 'mongo'], $services);
     }
 
     /** @psalm-return array<string, array{0: string}> */


### PR DESCRIPTION
The `mongo` OAuth2 storage adapter — the Mongo counterpart to the db-connected surface and `MongoConnectedListener` removed from `api-tools` (#8, #9).

## What went

- the `'mongo'` case in `createStorageFromAdapter()`
- the private `createMongoAdapter()` and `createMongoDatabase()` builders
- the `MongoAdapter`, `MongoClient` and `MongoDB` imports
- Mongo config examples from `config/module.config.php` and **both** places in the README
- `$container` from `createStorageFromAdapter()` and its argument at the single call site — removing the mongo case orphaned it

## This drops no dependency

Being explicit, since the previous two PRs did: `MongoAdapter` comes from `api-tools-oauth2`, which stays, and `MongoClient` came from the legacy `mongo` extension, which was never a declared dependency. What this removes is **supported surface**, not a package.

## Verification that it is unused use it

Neither the primary consuming application nor a second consuming application has a mongo package in its lock or any Mongo reference in application code, and neither has **any** `api-tools-oauth2` storage configuration — no `adapter => 'mongo'`, no oauth2 config block at all.

## Tests

The three Mongo tests are replaced by one asserting `'mongo'` is now rejected:

```php
public function testMongoIsNoLongerAValidStorageAdapter(): void
```

Two of the three could only ever skip (`class_exists(MongoDB::class)`). The third, `testRaisesExceptionCreatingMongoBackedServerIfDatabaseIsMissing`, actually ran and asserted the `'database'`-missing message — it would now hit `'Invalid storage adapter type for OAuth2'`, so replacing it is required, not optional.

## Verification

| PHP | deps | result |
| --- | --- | --- |
| 8.2 | latest | phpunit 11.5.56 OK (186 tests, 542 assertions), psalm pass, phpcs pass |
| 8.2 | lowest | phpunit 11.5.50, same counts, 1 deprecation, phpcs pass |
| 8.5 | latest | phpunit 13.1.14, same counts, psalm pass, phpcs pass |
| 8.5 | lowest | phpunit 11.5.50, same counts, 15 deprecations, phpcs pass |

The deprecations are **pre-existing and unchanged** — verified at 15 on `1.10.x` before this change. They are all `bshaffer/oauth2-server-php` implicitly-nullable constructor parameters on PHP 8.4+, surfaced only because I run with `--display-all-issues`. The pre-change run also had `Skipped: 2`; those were the Mongo tests.

psalm baseline entries: 522 → 510. psalm on the prefer-lowest set fails on baseline drift between dependency sets, as elsewhere; CI runs psalm only on `[8.2, locked]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed MongoDB as a supported OAuth2 storage adapter.
  * Configurations using the `mongo` adapter are now rejected.

* **Documentation**
  * Updated configuration examples and documentation to cover only HTTP and PDO-backed OAuth2 adapters.

* **Bug Fixes**
  * Improved validation and error reporting for unsupported storage adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
