### PR TITLE
Make api-tools-oauth2 and bshaffer/oauth2-server-php optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,6 @@
         }
     },
     "require": {
-        "bshaffer/oauth2-server-php": "^1.14.1",
-        "laminas-api-tools/api-tools-oauth2": "^1.11",
         "laminas/laminas-authentication": "^2.19",
         "laminas/laminas-eventmanager": "^3.15",
         "laminas/laminas-http": "^2.23 || ^3.0",
@@ -47,6 +45,8 @@
         "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
+        "bshaffer/oauth2-server-php": "^1.14.1",
+        "laminas-api-tools/api-tools-oauth2": "^1.11",
         "laminas/laminas-coding-standard": "^3.1",
         "laminas/laminas-session": "^2.26",
         "phpspec/prophecy-phpunit": "^2.3",
@@ -95,5 +95,9 @@
             "type": "git",
             "url": "https://github.com/datasage/laminas-mvc"
         }
-    ]
+    ],
+    "suggest": {
+        "bshaffer/oauth2-server-php": "^1.14.1, required by the OAuth2 authentication adapter",
+        "laminas-api-tools/api-tools-oauth2": "^1.11, to use the OAuth2 authentication adapter"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62be544f018195def71383aa6c3b2c5e",
+    "content-hash": "24e8589064ada772c7e18f815080b562",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -54,346 +54,6 @@
                 }
             ],
             "time": "2025-02-20T17:42:39+00:00"
-        },
-        {
-            "name": "bshaffer/oauth2-server-php",
-            "version": "v1.14.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bshaffer/oauth2-server-php.git",
-                "reference": "1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6",
-                "reference": "1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.8",
-                "firebase/php-jwt": "^6.4",
-                "phpunit/phpunit": "^7.5||^8.0",
-                "predis/predis": "^1.1",
-                "thobbs/phpcassa": "dev-master",
-                "yoast/phpunit-polyfills": "^1.0"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
-                "firebase/php-jwt": "~v6.4 is required to use JWT features",
-                "mongodb/mongodb": "^1.1 is required to use MongoDB storage",
-                "predis/predis": "Required to use Redis storage",
-                "thobbs/phpcassa": "Required to use Cassandra storage"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "OAuth2": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brent Shaffer",
-                    "email": "bshafs@gmail.com",
-                    "homepage": "http://brentertainment.com"
-                }
-            ],
-            "description": "OAuth2 Server for PHP",
-            "homepage": "http://github.com/bshaffer/oauth2-server-php",
-            "keywords": [
-                "auth",
-                "oauth",
-                "oauth2"
-            ],
-            "support": {
-                "issues": "https://github.com/bshaffer/oauth2-server-php/issues",
-                "source": "https://github.com/bshaffer/oauth2-server-php/tree/v1.14.2"
-            },
-            "time": "2025-03-28T21:13:45+00:00"
-        },
-        {
-            "name": "laminas-api-tools/api-tools-api-problem",
-            "version": "1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/datasage/api-tools-api-problem",
-                "reference": "38bc98c443c70cb0e12253e0e9acd6562f39f046"
-            },
-            "require": {
-                "ext-json": "*",
-                "laminas/laminas-eventmanager": "^3.15",
-                "laminas/laminas-http": "^2.23",
-                "laminas/laminas-mvc": "^3.8",
-                "laminas/laminas-stdlib": "^3.21",
-                "laminas/laminas-view": "^2.43",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.1 || ^2"
-            },
-            "replace": {
-                "zfcampus/zf-api-problem": "^1.3.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~3",
-                "laminas/laminas-servicemanager": "^3.24",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^11.5 || ^12",
-                "psalm/plugin-phpunit": "^0.19",
-                "shipmonk/composer-dependency-analyser": "^1.8",
-                "symfony/console": "^6 || ^7 || ^8",
-                "symfony/filesystem": "^6 || ^7 || ^8",
-                "symfony/string": "^6 || ^7 || ^8",
-                "vimeo/psalm": "^6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ApiTools\\ApiProblem"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ApiTools\\ApiProblem\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "LaminasTest\\ApiTools\\ApiProblem\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "static-analysis": [
-                    "psalm --shepherd --stats"
-                ]
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas Module providing API-Problem assets and rendering",
-            "homepage": "https://api-tools.getlaminas.org",
-            "keywords": [
-                "api-problem",
-                "api-tools",
-                "laminas",
-                "module",
-                "rest"
-            ],
-            "support": {
-                "docs": "https://api-tools.getlaminas.org/documentation",
-                "issues": "https://github.com/laminas-api-tools/api-tools-api-problem/issues",
-                "source": "https://github.com/laminas-api-tools/api-tools-api-problem",
-                "rss": "https://github.com/laminas-api-tools/api-tools-api-problem/releases.atom",
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev"
-            },
-            "time": "2026-08-05T14:54:49+00:00"
-        },
-        {
-            "name": "laminas-api-tools/api-tools-content-negotiation",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/datasage/api-tools-content-negotiation",
-                "reference": "ad9cf485c3b16d8208cb3430adc0f06e1a009014"
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "laminas-api-tools/api-tools-api-problem": "^1.10",
-                "laminas/laminas-eventmanager": "^3.15",
-                "laminas/laminas-filter": "^2.42",
-                "laminas/laminas-http": "^2.23",
-                "laminas/laminas-json": "^3.8",
-                "laminas/laminas-mvc": "^3.8",
-                "laminas/laminas-servicemanager": "^3.24",
-                "laminas/laminas-stdlib": "^3.21",
-                "laminas/laminas-validator": "^2.65",
-                "laminas/laminas-view": "^2.43",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "replace": {
-                "zfcampus/zf-content-negotiation": "^1.4.0"
-            },
-            "require-dev": {
-                "laminas-api-tools/api-tools-hal": "^1.13",
-                "laminas/laminas-coding-standard": "^3",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^10",
-                "psalm/plugin-phpunit": "^0.19",
-                "vimeo/psalm": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ApiTools\\ContentNegotiation"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ApiTools\\ContentNegotiation\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "LaminasTest\\ApiTools\\ContentNegotiation\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "static-analysis": [
-                    "psalm --shepherd --stats"
-                ]
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas Module providing content-negotiation features",
-            "homepage": "https://api-tools.getlaminas.org",
-            "keywords": [
-                "api-tools",
-                "content-negotiation",
-                "laminas",
-                "module"
-            ],
-            "support": {
-                "docs": "https://api-tools.getlaminas.org/documentation",
-                "issues": "https://github.com/laminas-api-tools/api-tools-content-negotiation/issues",
-                "source": "https://github.com/laminas-api-tools/api-tools-content-negotiation",
-                "rss": "https://github.com/laminas-api-tools/api-tools-content-negotiation/releases.atom",
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev"
-            },
-            "time": "2026-08-05T15:27:02+00:00"
-        },
-        {
-            "name": "laminas-api-tools/api-tools-oauth2",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/datasage/api-tools-oauth2",
-                "reference": "8bd0526d727d9f9855c08d404ed79d9f8a4d981f"
-            },
-            "require": {
-                "bshaffer/oauth2-server-php": "^1.14.1",
-                "laminas-api-tools/api-tools-api-problem": "^1.10",
-                "laminas-api-tools/api-tools-content-negotiation": "^1.11",
-                "laminas/laminas-http": "^2.23",
-                "laminas/laminas-mvc": "^3.8",
-                "laminas/laminas-servicemanager": "^3.24",
-                "laminas/laminas-stdlib": "^3.21",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.1 || ^2.0",
-                "webmozart/assert": "^1.10"
-            },
-            "replace": {
-                "zfcampus/zf-oauth2": "^1.5.0"
-            },
-            "require-dev": {
-                "laminas/laminas-authentication": "^2.19",
-                "laminas/laminas-coding-standard": "^3",
-                "laminas/laminas-db": "^2.22",
-                "laminas/laminas-i18n": "^2.31",
-                "laminas/laminas-test": "^4.13",
-                "mockery/mockery": "^1.3.2",
-                "phpspec/prophecy-phpunit": "^2.1",
-                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
-                "psalm/plugin-phpunit": "^0.19",
-                "vimeo/psalm": "^6.14"
-            },
-            "suggest": {
-                "alcaeus/mongo-php-adapter": "^1.0.5, if you are using ext/mongodb and wish to use the MongoAdapter for OAuth2 credential storage."
-            },
-            "bin": [
-                "bin/bcrypt.php"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ApiTools\\OAuth2\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "LaminasTest\\ApiTools\\OAuth2\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "static-analysis": [
-                    "psalm --shepherd --stats"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ]
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Laminas module for implementing an OAuth2 server",
-            "homepage": "https://api-tools.getlaminas.org",
-            "keywords": [
-                "api",
-                "api-tools",
-                "framework",
-                "laminas",
-                "oauth2"
-            ],
-            "support": {
-                "docs": "https://api-tools.getlaminas.org/documentation",
-                "issues": "https://github.com/laminas-api-tools/api-tools-oauth2/issues",
-                "source": "https://github.com/laminas-api-tools/api-tools-oauth2",
-                "rss": "https://github.com/laminas-api-tools/api-tools-oauth2/releases.atom",
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev"
-            },
-            "time": "2026-08-05T21:14:00+00:00"
         },
         {
             "name": "laminas/laminas-authentication",
@@ -671,85 +331,6 @@
             "time": "2025-10-31T10:29:01+00:00"
         },
         {
-            "name": "laminas/laminas-filter",
-            "version": "2.42.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/985d27bd42daf51b415ce1ee889e0978cc1e59ed",
-                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.19.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "conflict": {
-                "laminas/laminas-validator": "<2.10.1",
-                "zendframework/zend-filter": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^3.1",
-                "laminas/laminas-crypt": "^3.12",
-                "laminas/laminas-i18n": "^2.30.0",
-                "laminas/laminas-uri": "^2.13",
-                "pear/archive_tar": "^1.6.0",
-                "phpunit/phpunit": "^10.5.58",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/http-factory": "^1.1.0",
-                "vimeo/psalm": "^5.26.1"
-            },
-            "suggest": {
-                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
-                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
-                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Filter",
-                    "config-provider": "Laminas\\Filter\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Filter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Programmatically filter and normalize data and files",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "filter",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-filter/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-filter/issues",
-                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
-                "source": "https://github.com/laminas/laminas-filter"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-10-13T15:44:52+00:00"
-        },
-        {
             "name": "laminas/laminas-http",
             "version": "2.23.0",
             "source": {
@@ -1010,11 +591,11 @@
         },
         {
             "name": "laminas/laminas-mvc",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/datasage/laminas-mvc",
-                "reference": "e313b42d44ed3821cf1a381180ac31b3029e977c"
+                "reference": "33bf7454e717101ad42fea63cb32378fee4e6ac6"
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
@@ -1031,8 +612,12 @@
                 "zendframework/zend-mvc": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0.1",
-                "phpunit/phpunit": "^10.5.38"
+                "amphp/dns": "^2.4",
+                "amphp/socket": "^2.4",
+                "laminas/laminas-coding-standard": "^3.1",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+                "psalm/plugin-phpunit": "^0.19",
+                "vimeo/psalm": "^6.14"
             },
             "suggest": {
                 "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
@@ -1095,7 +680,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev"
             },
-            "time": "2026-08-05T01:58:19+00:00"
+            "time": "2026-08-08T15:23:23+00:00"
         },
         {
             "name": "laminas/laminas-permissions-acl",
@@ -1906,64 +1491,6 @@
                 }
             ],
             "time": "2021-04-19T16:34:45+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
-            },
-            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
@@ -2785,6 +2312,68 @@
             "time": "2024-08-03T19:31:26+00:00"
         },
         {
+            "name": "bshaffer/oauth2-server-php",
+            "version": "v1.14.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bshaffer/oauth2-server-php.git",
+                "reference": "1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6",
+                "reference": "1c715c2d2f71254d1c683b8c89a0f16b61ccd0d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.8",
+                "firebase/php-jwt": "^6.4",
+                "phpunit/phpunit": "^7.5||^8.0",
+                "predis/predis": "^1.1",
+                "thobbs/phpcassa": "dev-master",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
+                "firebase/php-jwt": "~v6.4 is required to use JWT features",
+                "mongodb/mongodb": "^1.1 is required to use MongoDB storage",
+                "predis/predis": "Required to use Redis storage",
+                "thobbs/phpcassa": "Required to use Cassandra storage"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "OAuth2": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Shaffer",
+                    "email": "bshafs@gmail.com",
+                    "homepage": "http://brentertainment.com"
+                }
+            ],
+            "description": "OAuth2 Server for PHP",
+            "homepage": "http://github.com/bshaffer/oauth2-server-php",
+            "keywords": [
+                "auth",
+                "oauth",
+                "oauth2"
+            ],
+            "support": {
+                "issues": "https://github.com/bshaffer/oauth2-server-php/issues",
+                "source": "https://github.com/bshaffer/oauth2-server-php/tree/v1.14.2"
+            },
+            "time": "2025-03-28T21:13:45+00:00"
+        },
+        {
             "name": "composer/pcre",
             "version": "3.4.0",
             "source": {
@@ -3526,6 +3115,284 @@
             "time": "2023-02-03T21:26:53+00:00"
         },
         {
+            "name": "laminas-api-tools/api-tools-api-problem",
+            "version": "1.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/datasage/api-tools-api-problem",
+                "reference": "da8f2a19de7e745f7851a357e950bf8008dfe3f4"
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-eventmanager": "^3.15",
+                "laminas/laminas-http": "^2.23",
+                "laminas/laminas-mvc": "^3.8",
+                "laminas/laminas-stdlib": "^3.21",
+                "laminas/laminas-view": "^2.43",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.1 || ^2"
+            },
+            "replace": {
+                "zfcampus/zf-api-problem": "^1.3.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1",
+                "laminas/laminas-servicemanager": "^3.24",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+                "psalm/plugin-phpunit": "^0.19",
+                "shipmonk/composer-dependency-analyser": "^1.8",
+                "symfony/console": "^6 || ^7 || ^8",
+                "symfony/filesystem": "^6 || ^7 || ^8",
+                "symfony/string": "^6 || ^7 || ^8",
+                "vimeo/psalm": "^6.14"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ApiTools\\ApiProblem"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ApiTools\\ApiProblem\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\ApiTools\\ApiProblem\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "static-analysis": [
+                    "psalm --shepherd --stats"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas Module providing API-Problem assets and rendering",
+            "homepage": "https://api-tools.getlaminas.org",
+            "keywords": [
+                "api-problem",
+                "api-tools",
+                "laminas",
+                "module",
+                "rest"
+            ],
+            "support": {
+                "docs": "https://api-tools.getlaminas.org/documentation",
+                "issues": "https://github.com/laminas-api-tools/api-tools-api-problem/issues",
+                "source": "https://github.com/laminas-api-tools/api-tools-api-problem",
+                "rss": "https://github.com/laminas-api-tools/api-tools-api-problem/releases.atom",
+                "chat": "https://laminas.dev/chat",
+                "forum": "https://discourse.laminas.dev"
+            },
+            "time": "2026-08-08T12:45:49+00:00"
+        },
+        {
+            "name": "laminas-api-tools/api-tools-content-negotiation",
+            "version": "1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/datasage/api-tools-content-negotiation",
+                "reference": "ced599c1918eaf7abc28f8bcb800f13b72f24cc3"
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas-api-tools/api-tools-api-problem": "^1.10",
+                "laminas/laminas-eventmanager": "^3.15",
+                "laminas/laminas-filter": "^2.42",
+                "laminas/laminas-http": "^2.23",
+                "laminas/laminas-json": "^3.8",
+                "laminas/laminas-mvc": "^3.8",
+                "laminas/laminas-servicemanager": "^3.24",
+                "laminas/laminas-stdlib": "^3.21",
+                "laminas/laminas-validator": "^2.65",
+                "laminas/laminas-view": "^2.43",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "replace": {
+                "zfcampus/zf-content-negotiation": "^1.4.0"
+            },
+            "require-dev": {
+                "laminas-api-tools/api-tools-hal": "^1.13",
+                "laminas/laminas-coding-standard": "^3.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+                "psalm/plugin-phpunit": "^0.19",
+                "vimeo/psalm": "^6.14"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ApiTools\\ContentNegotiation"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ApiTools\\ContentNegotiation\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\ApiTools\\ContentNegotiation\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "static-analysis": [
+                    "psalm --shepherd --stats"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas Module providing content-negotiation features",
+            "homepage": "https://api-tools.getlaminas.org",
+            "keywords": [
+                "api-tools",
+                "content-negotiation",
+                "laminas",
+                "module"
+            ],
+            "support": {
+                "docs": "https://api-tools.getlaminas.org/documentation",
+                "issues": "https://github.com/laminas-api-tools/api-tools-content-negotiation/issues",
+                "source": "https://github.com/laminas-api-tools/api-tools-content-negotiation",
+                "rss": "https://github.com/laminas-api-tools/api-tools-content-negotiation/releases.atom",
+                "chat": "https://laminas.dev/chat",
+                "forum": "https://discourse.laminas.dev"
+            },
+            "time": "2026-08-08T14:33:40+00:00"
+        },
+        {
+            "name": "laminas-api-tools/api-tools-oauth2",
+            "version": "1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/datasage/api-tools-oauth2",
+                "reference": "28f559d8bb67f1991f40b5895c5a812426af5f06"
+            },
+            "require": {
+                "bshaffer/oauth2-server-php": "^1.14.1",
+                "laminas-api-tools/api-tools-api-problem": "^1.10",
+                "laminas-api-tools/api-tools-content-negotiation": "^1.11",
+                "laminas/laminas-http": "^2.23",
+                "laminas/laminas-mvc": "^3.8",
+                "laminas/laminas-servicemanager": "^3.24",
+                "laminas/laminas-stdlib": "^3.21",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.1 || ^2.0",
+                "webmozart/assert": "^1.10"
+            },
+            "replace": {
+                "zfcampus/zf-oauth2": "^1.5.0"
+            },
+            "require-dev": {
+                "laminas/laminas-authentication": "^2.19",
+                "laminas/laminas-coding-standard": "^3.1",
+                "laminas/laminas-db": "^2.22",
+                "laminas/laminas-i18n": "^2.31",
+                "laminas/laminas-test": "^4.13",
+                "mockery/mockery": "^1.3.2",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+                "psalm/plugin-phpunit": "^0.19",
+                "vimeo/psalm": "^6.14"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "^1.0.5, if you are using ext/mongodb and wish to use the MongoAdapter for OAuth2 credential storage."
+            },
+            "bin": [
+                "bin/bcrypt.php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ApiTools\\OAuth2\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\ApiTools\\OAuth2\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "static-analysis": [
+                    "psalm --shepherd --stats"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas module for implementing an OAuth2 server",
+            "homepage": "https://api-tools.getlaminas.org",
+            "keywords": [
+                "api",
+                "api-tools",
+                "framework",
+                "laminas",
+                "oauth2"
+            ],
+            "support": {
+                "docs": "https://api-tools.getlaminas.org/documentation",
+                "issues": "https://github.com/laminas-api-tools/api-tools-oauth2/issues",
+                "source": "https://github.com/laminas-api-tools/api-tools-oauth2",
+                "rss": "https://github.com/laminas-api-tools/api-tools-oauth2/releases.atom",
+                "chat": "https://laminas.dev/chat",
+                "forum": "https://discourse.laminas.dev"
+            },
+            "time": "2026-08-08T14:33:42+00:00"
+        },
+        {
             "name": "laminas/laminas-coding-standard",
             "version": "3.1.0",
             "source": {
@@ -3577,6 +3444,85 @@
                 }
             ],
             "time": "2025-05-13T08:37:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-filter",
+            "version": "2.42.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-filter.git",
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/985d27bd42daf51b415ce1ee889e0978cc1e59ed",
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "laminas/laminas-validator": "<2.10.1",
+                "zendframework/zend-filter": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.1",
+                "laminas/laminas-crypt": "^3.12",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-uri": "^2.13",
+                "pear/archive_tar": "^1.6.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
+                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
+                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
+                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Filter",
+                    "config-provider": "Laminas\\Filter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Filter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Programmatically filter and normalize data and files",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "filter",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-filter/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-filter/issues",
+                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
+                "source": "https://github.com/laminas/laminas-filter"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-13T15:44:52+00:00"
         },
         {
             "name": "laminas/laminas-session",
@@ -7403,6 +7349,64 @@
                 }
             ],
             "time": "2024-10-16T06:55:17+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Both move `require` → `require-dev`, with `suggest` entries documenting them. The OAuth2 adapter is one of several this package offers; a consumer using HTTP basic/digest or a custom adapter should not be made to install an OAuth2 server. The consuming applications authenticate through an external identity provider and have **no** `api-tools-oauth2` configuration at all.

## Why this is safe — the coupling is nowhere structural

- **No `extends`/`implements`** on any `api-tools-oauth2` type. `OAuth2Adapter extends AbstractAdapter` is this package's own class.
- **`Module::onMergeConfig` uses the factory only as `OAuth2ServerFactory::class`.** PHP resolves `::class` on a `use`-imported name at compile time to a string — no autoload, so it is safe with the class absent.
- **Both `new` sites are inside method bodies, behind config guards.**
  - `DefaultAuthenticationListenerFactory` returns `false` before reaching `new LaminasOAuth2ServerFactory()` unless `api-tools-oauth2.storage` is a string *and* resolves in the container.
  - `NamedOAuth2ServerFactory` is wired in only by `onMergeConfig`, which rewrites the `…OAuth2\Service\OAuth2Server` factory entry **only when it already exists** — and it exists only because api-tools-oauth2's own module config supplies it. No package, no entry, never invoked.
- **bshaffer's classes appear only as typed parameters** (resolved lazily) and as instantiations on those same guarded paths.

## Verified empirically, not just by reading

I removed both packages outright — from `require-dev` as well, so they were genuinely absent from `vendor/` — and ran the full suite:

```
Tests: 186, Assertions: 369, Errors: 28, Failures: 1.
```

**157 of 186 pass, and all 29 problems are OAuth2 paths**: `OAuth2AdapterTest`, `OAuth2ServerFactoryTest`, `NamedOAuth2ServerFactoryTest`, `AuthenticationOAuth2AdapterFactoryTest`, the bearer/access-token/`'oauth2'`-map cases in `DefaultAuthenticationListenerTest`, and `AuthenticationAdapterDelegatorFactoryTest::testReturnsListenerWithConfiguredAdapters`, which sets up an `api-tools-oauth2` config block explicitly. No bootstrap fatal, and nothing broken in the HTTP basic/digest paths.

They stay in `require-dev` so CI keeps exercising those 29: **186 tests, 542 assertions, psalm pass, phpcs pass** on the committed lock.

## BC break

A consumer relying on this package to pull OAuth2 in transitively must now require it directly.

## Note for the application rollout

This does not by itself remove the packages from the consuming application — `config/modules.config.php` still lists `'Laminas\ApiTools\OAuth2'`, and dropping the package without removing that line fatals at boot on a missing module. The two changes must land together.
